### PR TITLE
Fix for Stram web service calls failing in secure non-HA mode

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/security/StramWSFilter.java
+++ b/engine/src/main/java/com/datatorrent/stram/security/StramWSFilter.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.SecretManager;
 import org.apache.hadoop.security.token.Token;
 
 import com.datatorrent.stram.webapp.WebServices;
@@ -131,9 +132,8 @@ public class StramWSFilter implements Filter
 
     HttpServletRequest httpReq = (HttpServletRequest)req;
     HttpServletResponse httpResp = (HttpServletResponse)resp;
-    logger.debug("Remote address for request is: {}", httpReq.getRemoteAddr());
+    String remoteAddr = httpReq.getRemoteAddr();
     String requestURI = httpReq.getRequestURI();
-    logger.debug("Request path {}", requestURI);
     boolean authenticate = true;
     String user = null;
     if(getProxyAddresses().contains(httpReq.getRemoteAddr())) {
@@ -147,14 +147,15 @@ public class StramWSFilter implements Filter
       }
       if (requestURI.equals(WebServices.PATH) && (user != null)) {
         String token = createClientToken(user, httpReq.getLocalAddr());
-        logger.debug("Create token {}", token);
+        logger.debug("{}: creating token {}", remoteAddr, token);
         Cookie cookie = new Cookie(CLIENT_COOKIE, token);
         httpResp.addCookie(cookie);
+      } else {
+        logger.info("{}: proxy access to URI {} by user {}, no cookie created", remoteAddr, requestURI, user);
       }
       authenticate = false;
     }
     if (authenticate) {
-      logger.debug("Authenticating");
       Cookie cookie = null;
       if (httpReq.getCookies() != null) {
         for (Cookie c : httpReq.getCookies()) {
@@ -166,22 +167,24 @@ public class StramWSFilter implements Filter
       }
       boolean valid = false;
       if (cookie != null) {
-        logger.debug("Verifying token {}", cookie.getValue());
-        user = verifyClientToken(cookie.getValue());
-        valid = true;
-        logger.debug("Token valid");
+        user = verifyClientToken(cookie.getValue(), remoteAddr);
+        if (user != null) {
+          valid = true;
+        } else {
+          logger.debug("{}: invalid cookie {}", remoteAddr, cookie.getValue());
+        }
       } else {
-        logger.debug("Cookie not found");
+        logger.debug("{}: cookie not found {}", remoteAddr, CLIENT_COOKIE);
       }
       if (!valid) {
-        logger.debug("Auth failure {}", HttpServletResponse.SC_UNAUTHORIZED);
+        logger.debug("{}: auth failure", remoteAddr);
         httpResp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
         return;
       }
     }
 
     if(user == null) {
-      logger.debug("Could not find {} cookie, so user will not be set", WEBAPP_PROXY_USER);
+      logger.debug("{}: could not find user, so user principal will not be set", remoteAddr);
       chain.doFilter(req, resp);
     } else {
       final StramWSPrincipal principal = new StramWSPrincipal(user);
@@ -201,16 +204,31 @@ public class StramWSFilter implements Filter
     return token.encodeToUrlString();
   }
 
-  private String verifyClientToken(String tokenstr) throws IOException
+  private String verifyClientToken(String tokenstr, String cid) throws IOException
   {
     Token<StramDelegationTokenIdentifier> token = new Token<StramDelegationTokenIdentifier>();
-    token.decodeFromUrlString(tokenstr);
+    try {
+      token.decodeFromUrlString(tokenstr);
+    } catch (IOException e) {
+      logger.debug("{}: error decoding token: {}", cid, e.getMessage());
+      return null;
+    }
     byte[] identifier = token.getIdentifier();
     byte[] password = token.getPassword();
     StramDelegationTokenIdentifier tokenIdentifier = new StramDelegationTokenIdentifier();
     DataInputStream input = new DataInputStream(new ByteArrayInputStream(identifier));
-    tokenIdentifier.readFields(input);
-    tokenManager.verifyToken(tokenIdentifier, password);
+    try {
+      tokenIdentifier.readFields(input);
+    } catch (IOException e) {
+      logger.debug("{}: error decoding identifier: {}", cid, e.getMessage());
+      return null;
+    }
+    try {
+      tokenManager.verifyToken(tokenIdentifier, password);
+    } catch (SecretManager.InvalidToken e) {
+      logger.debug("{}: invalid token {}: {}", cid, tokenIdentifier, e.getMessage());
+      return null;
+    }
     return tokenIdentifier.getOwner().toString();
   }
 }

--- a/engine/src/main/java/com/datatorrent/stram/security/StramWSFilter.java
+++ b/engine/src/main/java/com/datatorrent/stram/security/StramWSFilter.java
@@ -99,6 +99,7 @@ public class StramWSFilter implements Filter
         proxyAddresses = new HashSet<String>();
         for (String proxyHost : proxyHosts) {
           try {
+            logger.debug("resolving proxy hostname {}", proxyHost);
             for (InetAddress add : InetAddress.getAllByName(proxyHost)) {
               logger.debug("proxy address is: {}", add.getHostAddress());
               proxyAddresses.add(add.getHostAddress());
@@ -153,6 +154,7 @@ public class StramWSFilter implements Filter
       authenticate = false;
     }
     if (authenticate) {
+      logger.debug("Authenticating");
       Cookie cookie = null;
       if (httpReq.getCookies() != null) {
         for (Cookie c : httpReq.getCookies()) {
@@ -168,8 +170,11 @@ public class StramWSFilter implements Filter
         user = verifyClientToken(cookie.getValue());
         valid = true;
         logger.debug("Token valid");
+      } else {
+        logger.debug("Cookie not found");
       }
       if (!valid) {
+        logger.debug("Auth failure {}", HttpServletResponse.SC_UNAUTHORIZED);
         httpResp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
         return;
       }

--- a/engine/src/main/java/com/datatorrent/stram/security/StramWSFilterInitializer.java
+++ b/engine/src/main/java/com/datatorrent/stram/security/StramWSFilterInitializer.java
@@ -23,6 +23,9 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.http.FilterContainer;
@@ -40,12 +43,15 @@ import com.datatorrent.stram.util.ConfigUtils;
  */
 public class StramWSFilterInitializer extends FilterInitializer
 {
+  private static final Logger logger = LoggerFactory.getLogger(StramWSFilterInitializer.class);
+
   private static final String FILTER_NAME = "AM_PROXY_FILTER";
   private static final String FILTER_CLASS = StramWSFilter.class.getCanonicalName();
 
   @Override
   public void initFilter(FilterContainer container, Configuration conf)
   {
+    logger.debug("Conf {}", conf);
     Map<String, String> params = new HashMap<String, String>();
     Collection<String> proxies = new ArrayList<String>();
     if (ConfigUtils.isRMHAEnabled(conf)) {
@@ -77,6 +83,8 @@ public class StramWSFilterInitializer extends FilterInitializer
   public String getProxyHostAndPort(Configuration conf)
   {
     String addr = conf.get(YarnConfiguration.PROXY_ADDRESS);
+    logger.info("proxy address setting {}", addr);
+    logger.debug("proxy setting sources {}", conf.getPropertySources(YarnConfiguration.PROXY_ADDRESS));
     if (addr == null || addr.isEmpty()) {
       addr = getResolvedRMWebAppURLWithoutScheme(conf, null);
     }
@@ -93,27 +101,29 @@ public class StramWSFilterInitializer extends FilterInitializer
     boolean sslEnabled = conf.getBoolean(
             CommonConfigurationKeysPublic.HADOOP_SSL_ENABLED_KEY,
             CommonConfigurationKeysPublic.HADOOP_SSL_ENABLED_DEFAULT);
-    return getResolvedRMWebAppURLWithoutScheme(conf, sslEnabled, (rmId != null) ? "." + rmId : null);
+    return getResolvedRMWebAppURLWithoutScheme(conf, sslEnabled, (rmId != null) ? "." + rmId : "");
   }
 
   /*
     From org.apache.hadoop.yarn.webapp.util.WebAppUtils
     Modified for HA support
   */
-  public String getResolvedRMWebAppURLWithoutScheme(Configuration conf, boolean sslEnabled, String rmId)
+  public String getResolvedRMWebAppURLWithoutScheme(Configuration conf, boolean sslEnabled, String rmPrpKey)
   {
     InetSocketAddress address = null;
     if (sslEnabled) {
       address =
-              conf.getSocketAddr(YarnConfiguration.RM_WEBAPP_HTTPS_ADDRESS + rmId,
+              conf.getSocketAddr(YarnConfiguration.RM_WEBAPP_HTTPS_ADDRESS + rmPrpKey,
                       YarnConfiguration.DEFAULT_RM_WEBAPP_HTTPS_ADDRESS,
                       YarnConfiguration.DEFAULT_RM_WEBAPP_HTTPS_PORT);
     } else {
       address =
-              conf.getSocketAddr(YarnConfiguration.RM_WEBAPP_ADDRESS + rmId,
+              conf.getSocketAddr(YarnConfiguration.RM_WEBAPP_ADDRESS + rmPrpKey,
                       YarnConfiguration.DEFAULT_RM_WEBAPP_ADDRESS,
                       YarnConfiguration.DEFAULT_RM_WEBAPP_PORT);
     }
+    logger.info("rm webapp address setting {}", address);
+    logger.debug("rm setting sources {}", conf.getPropertySources(YarnConfiguration.RM_WEBAPP_ADDRESS));
     address = NetUtils.getConnectAddress(address);
     StringBuffer sb = new StringBuffer();
     InetAddress resolved = address.getAddress();
@@ -130,6 +140,7 @@ public class StramWSFilterInitializer extends FilterInitializer
       sb.append(address.getHostName());
     }
     sb.append(":").append(address.getPort());
+    logger.info("rm webapp resolved hostname {}", sb.toString());
     return sb.toString();
   }
 


### PR DESCRIPTION
Fix for property name used to lookup RM webapp address in non-HA mode and additional log statements to help with debugging the request processing in future.
