### PR TITLE
License header formatting preparation.

### DIFF
--- a/api/src/main/java/com/datatorrent/api/annotation/Name.java
+++ b/api/src/main/java/com/datatorrent/api/annotation/Name.java
@@ -1,4 +1,3 @@
-
 /**
  * Copyright (C) 2015 DataTorrent, Inc.
  *

--- a/bufferserver/src/main/java/com/datatorrent/bufferserver/util/VarInt.java
+++ b/bufferserver/src/main/java/com/datatorrent/bufferserver/util/VarInt.java
@@ -1,4 +1,3 @@
-
 /**
  * Copyright (C) 2015 DataTorrent, Inc.
  *

--- a/common/src/main/java/com/datatorrent/common/metric/SingleMetricAggregator.java
+++ b/common/src/main/java/com/datatorrent/common/metric/SingleMetricAggregator.java
@@ -1,4 +1,3 @@
-
 /**
  * Copyright (C) 2015 DataTorrent, Inc.
  *

--- a/common/src/main/java/com/datatorrent/common/metric/sum/DoubleSumAggregator.java
+++ b/common/src/main/java/com/datatorrent/common/metric/sum/DoubleSumAggregator.java
@@ -1,4 +1,3 @@
-
 /**
  * Copyright (C) 2015 DataTorrent, Inc.
  *

--- a/common/src/main/java/com/datatorrent/common/metric/sum/LongSumAggregator.java
+++ b/common/src/main/java/com/datatorrent/common/metric/sum/LongSumAggregator.java
@@ -1,4 +1,3 @@
-
 /**
  * Copyright (C) 2015 DataTorrent, Inc.
  *

--- a/engine/src/main/java/com/datatorrent/stram/api/AppDataSource.java
+++ b/engine/src/main/java/com/datatorrent/stram/api/AppDataSource.java
@@ -1,4 +1,3 @@
-
 /**
  * Copyright (C) 2015 DataTorrent, Inc.
  *

--- a/engine/src/main/java/com/datatorrent/stram/engine/Slider.java
+++ b/engine/src/main/java/com/datatorrent/stram/engine/Slider.java
@@ -1,4 +1,3 @@
-
 /**
  * Copyright (C) 2015 DataTorrent, Inc.
  *

--- a/engine/src/main/java/com/datatorrent/stram/webapp/asm/CompactAnnotationNode.java
+++ b/engine/src/main/java/com/datatorrent/stram/webapp/asm/CompactAnnotationNode.java
@@ -1,4 +1,3 @@
-
 /**
  * Copyright (C) 2015 DataTorrent, Inc.
  *

--- a/engine/src/main/java/com/datatorrent/stram/webapp/asm/CompactFieldNode.java
+++ b/engine/src/main/java/com/datatorrent/stram/webapp/asm/CompactFieldNode.java
@@ -1,4 +1,3 @@
-
 /**
  * Copyright (C) 2015 DataTorrent, Inc.
  *

--- a/engine/src/main/java/com/datatorrent/stram/webapp/asm/FieldSignatureVisitor.java
+++ b/engine/src/main/java/com/datatorrent/stram/webapp/asm/FieldSignatureVisitor.java
@@ -1,4 +1,3 @@
-
 /**
  * Copyright (C) 2015 DataTorrent, Inc.
  *

--- a/license.txt
+++ b/license.txt
@@ -1,13 +1,16 @@
-Copyright (C) 2015 DataTorrent, Inc.
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
 
-        http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.

--- a/pom.xml
+++ b/pom.xml
@@ -81,10 +81,10 @@
           </properties>
           <excludes>
             <exclude>license.txt</exclude>
-            <exclude>**/*.xml</exclude>
             <exclude>**/*.md</exclude>
-            <exclude>src/test/resources/**</exclude>
-            <exclude>src/main/resources/**</exclude>
+            <exclude>**/*.txt</exclude>
+            <exclude>**/archetype-resources/**</exclude>
+            <exclude>src/test/resources/projects/basic/goal.txt</exclude>
           </excludes>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,9 @@
             <exclude>**/archetype-resources/**</exclude>
             <exclude>src/test/resources/projects/basic/goal.txt</exclude>
           </excludes>
+          <mapping>
+            <dtcli>SCRIPT_STYLE</dtcli>
+          </mapping>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Changes to enable subsequent formatting for all files:

```
mvn license:format -Dlicense.skip=false 
```
