### PR TITLE
APEX-184 

### DIFF
--- a/bufferserver/src/main/java/com/datatorrent/bufferserver/internal/LogicalNode.java
+++ b/bufferserver/src/main/java/com/datatorrent/bufferserver/internal/LogicalNode.java
@@ -264,8 +264,7 @@ public class LogicalNode implements DataListener
                   break;
               }
             }
-          }
-          else {
+          } else {
             while (ready && iterator.hasNext()) {
               SerializedData data = iterator.next();
               switch (data.buffer[data.dataOffset]) {
@@ -298,8 +297,10 @@ public class LogicalNode implements DataListener
         catch (InterruptedException ie) {
           throw new RuntimeException(ie);
         }
-      }
-      else {
+        if (!ready) {
+          iterator.suspend();
+        }
+      } else {
         catchUp();
       }
     }

--- a/bufferserver/src/main/java/com/datatorrent/bufferserver/server/Server.java
+++ b/bufferserver/src/main/java/com/datatorrent/bufferserver/server/Server.java
@@ -636,9 +636,14 @@ public class Server implements ServerListener
         {
           final int interestOps = key.interestOps();
           if ((interestOps & SelectionKey.OP_READ) == 0) {
-            logger.debug("Resuming read on key {} with attachment {}", key, key.attachment());
             read(0);
-            key.interestOps(interestOps | SelectionKey.OP_READ);
+            if (datalist.isClientSuspended(Publisher.this)) {
+              logger.debug("Keeping read on key {} with attachment {} suspended. ", key, key.attachment(), datalist);
+              datalist.notifyListeners();
+            } else {
+              logger.debug("Resuming read on key {} with attachment {}", key, key.attachment());
+              key.interestOps(interestOps | SelectionKey.OP_READ);
+            }
           }
         }
       });


### PR DESCRIPTION
Suspend DataListIterator and release block reference in case LogicalNode is not ready to send data to downstream operator. Do not enable read in resumeReadIfSuspended when not able to switch to a new buffer. Fix possible race condition in Block acquire.

@ilooner please pull and test. @243826, @PramodSSImmaneni please review
