### PR TITLE
APEX-217

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -4,6 +4,7 @@ Copyright (c) 2015 The Apache Software Foundation
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
+
 The initial developer of the original code is
 DataTorrent, Inc. (http://www.datatorrent.com)
 Copyright (c) 2012 - 2015. All Rights Reserved.

--- a/apex-app-archetype/src/main/appended-resources/META-INF/NOTICE.vm
+++ b/apex-app-archetype/src/main/appended-resources/META-INF/NOTICE.vm
@@ -1,0 +1,3 @@
+#if($project.properties.postNoticeText)
+$project.properties.postNoticeText
+#end

--- a/apex-conf-archetype/src/main/appended-resources/META-INF/NOTICE.vm
+++ b/apex-conf-archetype/src/main/appended-resources/META-INF/NOTICE.vm
@@ -1,0 +1,3 @@
+#if($project.properties.postNoticeText)
+$project.properties.postNoticeText
+#end

--- a/api/src/main/appended-resources/META-INF/NOTICE.vm
+++ b/api/src/main/appended-resources/META-INF/NOTICE.vm
@@ -1,0 +1,3 @@
+#if($project.properties.postNoticeText)
+$project.properties.postNoticeText
+#end

--- a/bufferserver/src/main/appended-resources/META-INF/NOTICE.vm
+++ b/bufferserver/src/main/appended-resources/META-INF/NOTICE.vm
@@ -1,0 +1,3 @@
+#if($project.properties.postNoticeText)
+$project.properties.postNoticeText
+#end

--- a/common/src/main/appended-resources/META-INF/NOTICE.vm
+++ b/common/src/main/appended-resources/META-INF/NOTICE.vm
@@ -1,0 +1,3 @@
+#if($project.properties.postNoticeText)
+$project.properties.postNoticeText
+#end

--- a/engine/src/main/appended-resources/META-INF/NOTICE.vm
+++ b/engine/src/main/appended-resources/META-INF/NOTICE.vm
@@ -1,0 +1,3 @@
+#if($project.properties.postNoticeText)
+$project.properties.postNoticeText
+#end

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
             <exclude>DISCLAIMER</exclude>
             <exclude>LICENSE</exclude>
             <exclude>NOTICE</exclude>
+            <exclude>**/NOTICE.vm</exclude>
             <exclude>**/*.md</exclude>
             <exclude>**/*.txt</exclude>
             <exclude>**/*.importorder</exclude>
@@ -191,6 +192,7 @@
             <exclude>**/*.md</exclude>
             <exclude>**/*.txt</exclude>
             <exclude>**/*.importorder</exclude>
+            <exclude>**/NOTICE.vm</exclude>
           </excludes>
         </configuration>
       </plugin>
@@ -360,6 +362,7 @@
         <distMgmtDevUrl>file://${project.build.directory}/mvn-repo</distMgmtDevUrl>
         <package.prefix>/opt/datatorrent</package.prefix>
         <package.groupname>dtorrent</package.groupname>
+        <postNoticeText>The initial developer of the original code is&#xA;DataTorrent, Inc. (http://www.datatorrent.com)&#xA;Copyright (c) 2012 - 2015. All Rights Reserved.</postNoticeText>
       </properties>
       <distributionManagement>
         <repository>


### PR DESCRIPTION
 added NOTICE.vm that generates original copyright in NOTICE. The workaround suggested in https://issues.apache.org/jira/browse/MASFRES-5.

@tweise please review
