### PR TITLE
 APEX-223 for release-3.1

### DIFF
--- a/bufferserver/src/main/java/com/datatorrent/bufferserver/server/Server.java
+++ b/bufferserver/src/main/java/com/datatorrent/bufferserver/server/Server.java
@@ -162,7 +162,7 @@ public class Server implements ServerListener
   private final int blockSize;
   private final int numberOfCacheBlocks;
 
-  public void handlePurgeRequest(PurgeRequestTuple request, final AbstractLengthPrependerClient ctx) throws IOException
+  private void handlePurgeRequest(PurgeRequestTuple request, final AbstractLengthPrependerClient ctx) throws IOException
   {
     DataList dl;
     dl = publisherBuffers.get(request.getIdentifier());
@@ -178,16 +178,7 @@ public class Server implements ServerListener
 
     final byte[] tuple = PayloadTuple.getSerializedTuple(0, message.length);
     System.arraycopy(message, 0, tuple, tuple.length - message.length, message.length);
-    serverHelperExecutor.submit(new Runnable()
-    {
-      @Override
-      public void run()
-      {
-        ctx.write(tuple);
-        eventloop.disconnect(ctx);
-      }
-
-    });
+    ctx.write(tuple);
   }
 
   private void handleResetRequest(ResetRequestTuple request, final AbstractLengthPrependerClient ctx) throws IOException
@@ -210,16 +201,7 @@ public class Server implements ServerListener
 
     final byte[] tuple = PayloadTuple.getSerializedTuple(0, message.length);
     System.arraycopy(message, 0, tuple, tuple.length - message.length, message.length);
-    serverHelperExecutor.submit(new Runnable()
-    {
-      @Override
-      public void run()
-      {
-        ctx.write(tuple);
-        eventloop.disconnect(ctx);
-      }
-
-    });
+    ctx.write(tuple);
   }
 
   /**


### PR DESCRIPTION
Send response to purge/reset requestor on the same thread (defaultEventLoop). Do not explicitly disconnect, wait for the client to decide whether to send more requests or to disconnect.
