### PR TITLE
APEX-229 & APEX-228

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,10 @@
     </license>
   </licenses>
 
+  <prerequisites>
+    <maven>3.0.5</maven>
+  </prerequisites>
+
   <repositories>
     <!-- added for semantic versioning check, won't be needed once we publish to central -->
     <repository>
@@ -307,12 +311,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>2.16</version>
+          <version>2.17</version>
           <dependencies>
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <version>6.11</version>
+              <version>6.11.2</version>
             </dependency>
           </dependencies>
           <executions>


### PR DESCRIPTION
APEX-229 upgraded checkstyle maven plugin to 2.17 and checkstyle to 6.11.2
APEX-228 added maven 3.0.5 as prerequisite.

@chandnisingh, @tweise please review.
