### PR TITLE
APEX-103: Add module and dag interface in API

### DIFF
--- a/api/src/main/java/com/datatorrent/api/DAG.java
+++ b/api/src/main/java/com/datatorrent/api/DAG.java
@@ -164,6 +164,8 @@ public interface DAG extends DAGContext, Serializable
   {
     String getName();
 
+    Module getModule();
+
     InputPortMeta getMeta(Operator.InputPort<?> port);
 
     OutputPortMeta getMeta(Operator.OutputPort<?> port);

--- a/api/src/main/java/com/datatorrent/api/DAG.java
+++ b/api/src/main/java/com/datatorrent/api/DAG.java
@@ -165,10 +165,6 @@ public interface DAG extends DAGContext, Serializable
     String getName();
 
     Module getModule();
-
-    InputPortMeta getMeta(Operator.InputPort<?> port);
-
-    OutputPortMeta getMeta(Operator.OutputPort<?> port);
   }
 
   /**

--- a/api/src/main/java/com/datatorrent/api/Module.java
+++ b/api/src/main/java/com/datatorrent/api/Module.java
@@ -21,8 +21,127 @@ package com.datatorrent.api;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 
+import com.datatorrent.api.Context.PortContext;
+import com.datatorrent.api.Operator.InputPort;
+import com.datatorrent.api.Operator.OutputPort;
+import com.datatorrent.api.Operator.Unifier;
+
+/**
+ * A Module is a component which can be added to the DAG similar to the operator,
+ * using addModule API. The module should implement populateDAG method, which
+ * will be called by the platform, and DAG populated by the module will be
+ * replace in place of the module.
+ *
+ */
 @InterfaceStability.Evolving
 public interface Module
 {
   void populateDAG(DAG dag, Configuration conf);
+
+  /**
+   * These ports allow platform to short circuit module port to the operator port.
+   * i.e When a module is expanded, it can specify  which operator's port is used
+   * to replaced the module port in the final DAG.
+   * @param <T> data type accepted at the input port.
+   */
+  final class ProxyInputPort<T> implements InputPort<T>
+  {
+    InputPort<T> inputPort;
+
+    public void set(InputPort<T> port)
+    {
+      inputPort = port;
+    }
+
+    public InputPort<T> get()
+    {
+      return inputPort;
+    }
+
+    @Override
+    public void setup(PortContext context)
+    {
+      if (inputPort != null) {
+        inputPort.setup(context);
+      }
+    }
+
+    @Override
+    public void teardown()
+    {
+      if (inputPort != null) {
+        inputPort.teardown();
+      }
+    }
+
+    @Override
+    public Sink<T> getSink()
+    {
+      return inputPort == null ? null : inputPort.getSink();
+    }
+
+    @Override
+    public void setConnected(boolean connected)
+    {
+      if (inputPort != null) {
+        inputPort.setConnected(connected);
+      }
+    }
+
+    @Override
+    public StreamCodec<T> getStreamCodec()
+    {
+      return inputPort == null ? null : inputPort.getStreamCodec();
+    }
+  }
+
+  /**
+   * Similar to ProxyInputPort, but on output side.
+   * @param <T> datatype emitted on the port.
+   */
+  final class ProxyOutputPort<T> implements OutputPort<T>
+  {
+    OutputPort<T> outputPort;
+
+    public void set(OutputPort<T> port)
+    {
+      outputPort = port;
+    }
+
+    public OutputPort<T> get()
+    {
+      return outputPort;
+    }
+
+    @Override
+    public void setup(PortContext context)
+    {
+      if (outputPort != null) {
+        outputPort.setup(context);
+      }
+    }
+
+    @Override
+    public void teardown()
+    {
+      if (outputPort != null) {
+        outputPort.teardown();
+      }
+    }
+
+    @Override
+    public void setSink(Sink<Object> s)
+    {
+      if (outputPort != null) {
+        outputPort.setSink(s);
+      }
+    }
+
+    @Override
+    public Unifier<T> getUnifier()
+    {
+      return outputPort == null ? null : outputPort.getUnifier();
+    }
+  }
 }
+

--- a/engine/src/main/java/com/datatorrent/stram/cli/DTCli.java
+++ b/engine/src/main/java/com/datatorrent/stram/cli/DTCli.java
@@ -2824,7 +2824,7 @@ public class DTCli
               }
               LogicalPlan logicalPlan = appFactory.createApp(submitApp.getLogicalPlanConfiguration());
               map.put("applicationName", appFactory.getName());
-              map.put("logicalPlan", LogicalPlanSerializer.convertToMap(logicalPlan));
+              map.put("logicalPlan", LogicalPlanSerializer.convertToMap(logicalPlan, false));
             } finally {
               if (raw) {
                 System.setOut(originalStream);
@@ -2840,7 +2840,7 @@ public class DTCli
             LogicalPlan logicalPlan = appFactory.createApp(submitApp.getLogicalPlanConfiguration());
             Map<String, Object> map = new HashMap<String, Object>();
             map.put("applicationName", appFactory.getName());
-            map.put("logicalPlan", LogicalPlanSerializer.convertToMap(logicalPlan));
+            map.put("logicalPlan", LogicalPlanSerializer.convertToMap(logicalPlan, false));
             printJson(map);
           } else if (filename.endsWith(".properties")) {
             File file = new File(filename);
@@ -2849,7 +2849,7 @@ public class DTCli
             LogicalPlan logicalPlan = appFactory.createApp(submitApp.getLogicalPlanConfiguration());
             Map<String, Object> map = new HashMap<String, Object>();
             map.put("applicationName", appFactory.getName());
-            map.put("logicalPlan", LogicalPlanSerializer.convertToMap(logicalPlan));
+            map.put("logicalPlan", LogicalPlanSerializer.convertToMap(logicalPlan, false));
             printJson(map);
           } else {
             StramAppLauncher submitApp = getStramAppLauncher(filename, config, commandLineInfo.ignorePom);
@@ -2893,7 +2893,7 @@ public class DTCli
               Map<String, Object> map = new HashMap<String, Object>();
               map.put("applicationName", appInfo.name);
               if (appInfo.dag != null) {
-                map.put("logicalPlan", LogicalPlanSerializer.convertToMap(appInfo.dag));
+                map.put("logicalPlan", LogicalPlanSerializer.convertToMap(appInfo.dag, false));
               }
               if (appInfo.error != null) {
                 map.put("error", appInfo.error);

--- a/engine/src/main/java/com/datatorrent/stram/codec/LogicalPlanSerializer.java
+++ b/engine/src/main/java/com/datatorrent/stram/codec/LogicalPlanSerializer.java
@@ -212,7 +212,7 @@ public class LogicalPlanSerializer extends JsonSerializer<LogicalPlan>
       String operatorKey = LogicalPlanConfiguration.OPERATOR_PREFIX + operatorMeta.getName();
       Operator operator = operatorMeta.getOperator();
       props.setProperty(operatorKey + "." + LogicalPlanConfiguration.OPERATOR_CLASSNAME, operator.getClass().getName());
-      BeanMap operatorProperties = LogicalPlanConfiguration.getOperatorProperties(operator);
+      BeanMap operatorProperties = LogicalPlanConfiguration.getObjectProperties(operator);
       @SuppressWarnings("rawtypes")
       Iterator entryIterator = operatorProperties.entryIterator();
       while (entryIterator.hasNext()) {

--- a/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlan.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlan.java
@@ -156,6 +156,7 @@ public class LogicalPlan implements Serializable, DAG
   private final Attribute.AttributeMap attributes = new DefaultAttributeMap();
   private transient int nodeIndex = 0; // used for cycle validation
   private transient Stack<OperatorMeta> stack = new Stack<OperatorMeta>(); // used for cycle validation
+  // streamLinks is used for connecting proxy ports to actual ports. This is not needed after dag is fully expanded.
   private transient Map<String, ArrayListMultimap<OutputPort<?>, InputPort<?>>> streamLinks = new HashMap<String, ArrayListMultimap<Operator.OutputPort<?>, Operator.InputPort<?>>>();
 
   @Override

--- a/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlanConfiguration.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlanConfiguration.java
@@ -2116,10 +2116,18 @@ public class LogicalPlanConfiguration {
 
     // Expand the modules within the dag recursively
     setModuleProperties(dag, appName);
+    flattenDAG(dag, conf);
 
     // inject external operator configuration
     setOperatorConfiguration(dag, appConfs, appName);
     setStreamConfiguration(dag, appConfs, appName);
+  }
+
+  private void flattenDAG(LogicalPlan dag, Configuration conf)
+  {
+    for (ModuleMeta moduleMeta : dag.getAllModules()) {
+      moduleMeta.flattenModule(dag, conf);
+    }
   }
 
   public static Properties readProperties(String filePath) throws IOException

--- a/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlanConfiguration.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlanConfiguration.java
@@ -2128,6 +2128,7 @@ public class LogicalPlanConfiguration {
     for (ModuleMeta moduleMeta : dag.getAllModules()) {
       moduleMeta.flattenModule(dag, conf);
     }
+    dag.applyStreamLinks();
   }
 
   public static Properties readProperties(String filePath) throws IOException

--- a/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlanConfiguration.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlanConfiguration.java
@@ -18,7 +18,6 @@
  */
 package com.datatorrent.stram.plan.logical;
 
-
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,7 +30,6 @@ import java.lang.reflect.Type;
 
 import java.util.*;
 import java.util.Map.Entry;
-
 
 import javax.validation.ValidationException;
 
@@ -47,6 +45,7 @@ import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.apache.commons.beanutils.BeanMap;
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.collections.CollectionUtils;
@@ -61,10 +60,10 @@ import com.datatorrent.api.Context.DAGContext;
 import com.datatorrent.api.Context.OperatorContext;
 import com.datatorrent.api.Context.PortContext;
 import com.datatorrent.api.annotation.ApplicationAnnotation;
-
 import com.datatorrent.stram.StramUtils;
 import com.datatorrent.stram.client.StramClientUtils;
 import com.datatorrent.stram.plan.logical.LogicalPlan.InputPortMeta;
+import com.datatorrent.stram.plan.logical.LogicalPlan.ModuleMeta;
 import com.datatorrent.stram.plan.logical.LogicalPlan.OperatorMeta;
 import com.datatorrent.stram.plan.logical.LogicalPlan.OutputPortMeta;
 import com.datatorrent.stram.plan.logical.LogicalPlan.StreamMeta;
@@ -2114,6 +2113,10 @@ public class LogicalPlanConfiguration {
     if (dag.getAttributes().get(Context.DAGContext.APPLICATION_NAME) == null) {
       dag.setAttribute(Context.DAGContext.APPLICATION_NAME, appName);
     }
+
+    // Expand the modules within the dag recursively
+    setModuleProperties(dag, appName);
+
     // inject external operator configuration
     setOperatorConfiguration(dag, appConfs, appName);
     setStreamConfiguration(dag, appConfs, appName);
@@ -2138,7 +2141,7 @@ public class LogicalPlanConfiguration {
   public Map<String, String> getProperties(OperatorMeta ow, String appName) {
     List<AppConf> appConfs = stramConf.getMatchingChildConf(appName, StramElement.APPLICATION);
     List<OperatorConf> opConfs = getMatchingChildConf(appConfs, ow.getName(), StramElement.OPERATOR);
-    return getProperties(ow, opConfs, appName);
+    return getProperties(getPropertyArgs(ow), opConfs, appName);
   }
 
   private Map<String,String> getApplicationProperties(List<AppConf> appConfs){
@@ -2153,17 +2156,17 @@ public class LogicalPlanConfiguration {
   /**
    * Get the configuration opProps for the given operator.
    * These can be operator specific settings or settings from matching templates.
-   * @param ow
+   * @param pa
    * @param opConfs
    * @param appName
    */
-  private Map<String, String> getProperties(OperatorMeta ow, List<OperatorConf> opConfs, String appName)
+  private Map<String, String> getProperties(PropertyArgs pa, List<OperatorConf> opConfs, String appName)
   {
     Map<String, String> opProps = Maps.newHashMap();
     Map<String, TemplateConf> templates = stramConf.getChildren(StramElement.TEMPLATE);
     // list of all templates that match operator, ordered by priority
     if (!templates.isEmpty()) {
-      TreeMap<Integer, TemplateConf> matchingTemplates = getMatchingTemplates(ow, appName, templates);
+      TreeMap<Integer, TemplateConf> matchingTemplates = getMatchingTemplates(pa, appName, templates);
       if (matchingTemplates != null && !matchingTemplates.isEmpty()) {
         // combined map of prioritized template settings
         for (TemplateConf t : matchingTemplates.descendingMap().values()) {
@@ -2197,23 +2200,46 @@ public class LogicalPlanConfiguration {
     return refTemplates;
   }
 
+  private static class PropertyArgs
+  {
+    String name;
+    String className;
+
+    public PropertyArgs(String name, String className)
+    {
+      this.name = name;
+      this.className = className;
+    }
+  }
+
+  private PropertyArgs getPropertyArgs(OperatorMeta om)
+  {
+    return new PropertyArgs(om.getName(), om.getOperator().getClass().getName());
+  }
+
+  private PropertyArgs getPropertyArgs(ModuleMeta mm)
+  {
+    return new PropertyArgs(mm.getName(), mm.getModule().getClass().getName());
+  }
+
   /**
    * Produce the collections of templates that apply for the given id.
-   * @param ow
+   * @param pa
    * @param appName
    * @param templates
    * @return TreeMap<Integer, TemplateConf>
    */
-  private TreeMap<Integer, TemplateConf> getMatchingTemplates(OperatorMeta ow, String appName, Map<String, TemplateConf> templates) {
+  private TreeMap<Integer, TemplateConf> getMatchingTemplates(PropertyArgs pa, String appName, Map<String, TemplateConf> templates)
+  {
     TreeMap<Integer, TemplateConf> tm = Maps.newTreeMap();
     for (TemplateConf t : templates.values()) {
-      if ((t.idRegExp != null && ow.getName().matches(t.idRegExp))) {
+      if ((t.idRegExp != null && pa.name.matches(t.idRegExp))) {
         tm.put(1, t);
       } else if (appName != null && t.appNameRegExp != null
           && appName.matches(t.appNameRegExp)) {
         tm.put(2, t);
       } else if (t.classNameRegExp != null
-          && ow.getOperator().getClass().getName().matches(t.classNameRegExp)) {
+          && pa.className.matches(t.classNameRegExp)) {
         tm.put(3, t);
       }
     }
@@ -2238,6 +2264,26 @@ public class LogicalPlanConfiguration {
     }
   }
 
+  /**
+   * Generic helper function to inject properties on the object.
+   *
+   * @param obj
+   * @param properties
+   * @param <T>
+   * @return
+   */
+  public static <T> T setObjectProperties(T obj, Map<String, String> properties)
+  {
+    try {
+      BeanUtils.populate(obj, properties);
+      return obj;
+    } catch (IllegalAccessException e) {
+      throw new IllegalArgumentException("Error setting operator properties", e);
+    } catch (InvocationTargetException e) {
+      throw new IllegalArgumentException("Error setting operator properties", e);
+    }
+  }
+
   public static StreamingApplication setApplicationProperties(StreamingApplication application, Map<String, String> properties)
   {
     try {
@@ -2249,9 +2295,9 @@ public class LogicalPlanConfiguration {
     }
   }
 
-  public static BeanMap getOperatorProperties(Operator operator)
+  public static BeanMap getObjectProperties(Object obj)
   {
-    return new BeanMap(operator);
+    return new BeanMap(obj);
   }
 
   /**
@@ -2266,9 +2312,23 @@ public class LogicalPlanConfiguration {
     List<AppConf> appConfs = stramConf.getMatchingChildConf(applicationName, StramElement.APPLICATION);
     for (OperatorMeta ow : dag.getAllOperators()) {
       List<OperatorConf> opConfs = getMatchingChildConf(appConfs, ow.getName(), StramElement.OPERATOR);
-      Map<String, String> opProps = getProperties(ow, opConfs, applicationName);
+      Map<String, String> opProps = getProperties(getPropertyArgs(ow), opConfs, applicationName);
       setOperatorProperties(ow.getOperator(), opProps);
     }
+  }
+
+  /**
+   * Set any properties from configuration on the modules in the DAG. This
+   * method may throw unchecked exception if the configuration contains
+   * properties that are invalid for a module.
+   *
+   * @param dag
+   * @param applicationName
+   */
+  public void setModuleProperties(LogicalPlan dag, String applicationName)
+  {
+    List<AppConf> appConfs = stramConf.getMatchingChildConf(applicationName, StramElement.APPLICATION);
+    setModuleConfiguration(dag, appConfs, applicationName);
   }
 
   /**
@@ -2298,7 +2358,7 @@ public class LogicalPlanConfiguration {
       // Set the operator attributes
       setAttributes(opConfs, ow.getAttributes());
       // Set the operator opProps
-      Map<String, String> opProps = getProperties(ow, opConfs, appName);
+      Map<String, String> opProps = getProperties(getPropertyArgs(ow), opConfs, appName);
       setOperatorProperties(ow.getOperator(), opProps);
 
       // Set the port attributes
@@ -2324,6 +2384,15 @@ public class LogicalPlanConfiguration {
         }
       }
       ow.populateAggregatorMeta();
+    }
+  }
+
+  private void setModuleConfiguration(final LogicalPlan dag, List<AppConf> appConfs, String appName)
+  {
+    for (final ModuleMeta mw : dag.getAllModules()) {
+      List<OperatorConf> opConfs = getMatchingChildConf(appConfs, mw.getName(), StramElement.OPERATOR);
+      Map<String, String> opProps = getProperties(getPropertyArgs(mw), opConfs, appName);
+      setObjectProperties(mw.getModule(), opProps);
     }
   }
 

--- a/engine/src/main/java/com/datatorrent/stram/webapp/StramWebServices.java
+++ b/engine/src/main/java/com/datatorrent/stram/webapp/StramWebServices.java
@@ -715,7 +715,7 @@ public class StramWebServices
       throw new NotFoundException();
     }
 
-    BeanMap operatorProperties = LogicalPlanConfiguration.getOperatorProperties(logicalOperator.getOperator());
+    BeanMap operatorProperties = LogicalPlanConfiguration.getObjectProperties(logicalOperator.getOperator());
     Map<String, Object> m = new HashMap<String, Object>();
     @SuppressWarnings("rawtypes")
     Iterator entryIterator = operatorProperties.entryIterator();

--- a/engine/src/test/java/com/datatorrent/stram/plan/logical/module/ModuleAppTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/plan/logical/module/ModuleAppTest.java
@@ -1,0 +1,167 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.datatorrent.stram.plan.logical.module;
+
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.conf.Configuration;
+
+import com.datatorrent.api.DAG;
+import com.datatorrent.api.DefaultInputPort;
+import com.datatorrent.api.DefaultOutputPort;
+import com.datatorrent.api.InputOperator;
+import com.datatorrent.api.Module;
+import com.datatorrent.api.StreamingApplication;
+import com.datatorrent.common.util.BaseOperator;
+import com.datatorrent.stram.plan.logical.LogicalPlan;
+import com.datatorrent.stram.plan.logical.LogicalPlanConfiguration;
+
+/**
+ * Unit tests for testing Dag expansion with modules and proxy port substitution
+ */
+public class ModuleAppTest
+{
+
+  /*
+   * Input Operator - 1
+   */
+  static class DummyInputOperator extends BaseOperator implements InputOperator
+  {
+
+    Random r = new Random();
+    public transient DefaultOutputPort<Integer> output = new DefaultOutputPort<Integer>();
+
+    @Override
+    public void emitTuples()
+    {
+      output.emit(r.nextInt());
+    }
+  }
+
+  /*
+   * Input Operator - 1.1
+   */
+  static class DummyOperatorAfterInput extends BaseOperator
+  {
+
+    public transient DefaultInputPort<Integer> input = new DefaultInputPort<Integer>()
+    {
+      @Override
+      public void process(Integer tuple)
+      {
+        output.emit(tuple);
+      }
+    };
+    public transient DefaultOutputPort<Integer> output = new DefaultOutputPort<Integer>();
+  }
+
+  /*
+   * Operator - 2
+   */
+  static class DummyOperator extends BaseOperator
+  {
+    int prop;
+
+    public transient DefaultInputPort<Integer> input = new DefaultInputPort<Integer>()
+    {
+      @Override
+      public void process(Integer tuple)
+      {
+        LOG.debug(tuple.intValue() + " processed");
+        output.emit(tuple);
+      }
+    };
+    public transient DefaultOutputPort<Integer> output = new DefaultOutputPort<Integer>();
+  }
+
+  /*
+   * Output Operator - 3
+   */
+  static class DummyOutputOperator extends BaseOperator
+  {
+    int prop;
+
+    public transient DefaultInputPort<Integer> input = new DefaultInputPort<Integer>()
+    {
+      @Override
+      public void process(Integer tuple)
+      {
+        LOG.debug(tuple.intValue() + " processed");
+      }
+    };
+  }
+
+  /*
+   * Module Definition
+   */
+  static class TestModule implements Module
+  {
+
+    public transient ProxyInputPort<Integer> moduleInput = new Module.ProxyInputPort<Integer>();
+    public transient ProxyOutputPort<Integer> moduleOutput = new Module.ProxyOutputPort<Integer>();
+
+    @Override
+    public void populateDAG(DAG dag, Configuration conf)
+    {
+      LOG.debug("Module - PopulateDAG");
+      DummyOperator dummyOperator = dag.addOperator("DummyOperator", new DummyOperator());
+      moduleInput.set(dummyOperator.input);
+      moduleOutput.set(dummyOperator.output);
+    }
+  }
+
+  static class Application implements StreamingApplication
+  {
+    @Override
+    public void populateDAG(DAG dag, Configuration conf)
+    {
+      LOG.debug("Application - PopulateDAG");
+      DummyInputOperator dummyInputOperator = dag.addOperator("DummyInputOperator", new DummyInputOperator());
+      DummyOperatorAfterInput dummyOperatorAfterInput = dag.addOperator("DummyOperatorAfterInput", new DummyOperatorAfterInput());
+      Module m1 = dag.addModule("TestModule1", new TestModule());
+      Module m2 = dag.addModule("TestModule2", new TestModule());
+      DummyOutputOperator dummyOutputOperator = dag.addOperator("DummyOutputOperator", new DummyOutputOperator());
+      dag.addStream("Operator To Operator", dummyInputOperator.output, dummyOperatorAfterInput.input);
+      dag.addStream("Operator To Module", dummyOperatorAfterInput.output, ((TestModule)m1).moduleInput);
+      dag.addStream("Module To Module", ((TestModule)m1).moduleOutput, ((TestModule)m2).moduleInput);
+      dag.addStream("Module To Operator", ((TestModule)m2).moduleOutput, dummyOutputOperator.input);
+    }
+  }
+
+  @Test
+  public void validateTestApplication()
+  {
+    Configuration conf = new Configuration(false);
+    LogicalPlanConfiguration lpc = new LogicalPlanConfiguration(conf);
+    LogicalPlan dag = new LogicalPlan();
+    lpc.prepareDAG(dag, new Application(), "TestApp");
+
+    Assert.assertEquals(2, dag.getAllModules().size(), 2);
+    Assert.assertEquals(5, dag.getAllOperators().size());
+    Assert.assertEquals(4, dag.getAllStreams().size());
+    dag.validate();
+  }
+
+  private static Logger LOG = LoggerFactory.getLogger(ModuleAppTest.class);
+}

--- a/engine/src/test/java/com/datatorrent/stram/plan/logical/module/TestModuleExpansion.java
+++ b/engine/src/test/java/com/datatorrent/stram/plan/logical/module/TestModuleExpansion.java
@@ -1,0 +1,542 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.datatorrent.stram.plan.logical.module;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.apache.hadoop.conf.Configuration;
+
+import com.datatorrent.api.DAG;
+import com.datatorrent.api.DefaultInputPort;
+import com.datatorrent.api.DefaultOutputPort;
+import com.datatorrent.api.InputOperator;
+import com.datatorrent.api.Module;
+import com.datatorrent.api.StreamingApplication;
+import com.datatorrent.api.annotation.InputPortFieldAnnotation;
+import com.datatorrent.api.annotation.OutputPortFieldAnnotation;
+import com.datatorrent.common.util.BaseOperator;
+import com.datatorrent.stram.plan.logical.LogicalPlan;
+import com.datatorrent.stram.plan.logical.LogicalPlanConfiguration;
+
+public class TestModuleExpansion
+{
+  static class DummyInputOperator extends BaseOperator implements InputOperator
+  {
+    private int inputOperatorProp = 0;
+
+    Random r = new Random();
+    public transient DefaultOutputPort<Integer> out = new DefaultOutputPort<Integer>();
+
+    @Override
+    public void emitTuples()
+    {
+      out.emit(r.nextInt());
+    }
+
+    public int getInputOperatorProp()
+    {
+      return inputOperatorProp;
+    }
+
+    public void setInputOperatorProp(int inputOperatorProp)
+    {
+      this.inputOperatorProp = inputOperatorProp;
+    }
+  }
+
+  static class DummyOperator extends BaseOperator
+  {
+    private int operatorProp = 0;
+
+    @OutputPortFieldAnnotation(optional = true)
+    public transient final DefaultOutputPort<Integer> out1 = new DefaultOutputPort<>();
+
+    @OutputPortFieldAnnotation(optional = true)
+    public transient final DefaultOutputPort<Integer> out2 = new DefaultOutputPort<>();
+
+    @InputPortFieldAnnotation(optional = true)
+    public transient final DefaultInputPort<Integer> in = new DefaultInputPort<Integer>()
+    {
+      @Override
+      public void process(Integer tuple)
+      {
+        out1.emit(tuple);
+        out2.emit(tuple);
+      }
+    };
+
+    public int getOperatorProp()
+    {
+      return operatorProp;
+    }
+
+    public void setOperatorProp(int operatorProp)
+    {
+      this.operatorProp = operatorProp;
+    }
+  }
+
+  static class Level1Module implements Module
+  {
+    private int level1ModuleProp = 0;
+
+    @InputPortFieldAnnotation(optional = true)
+    public transient final ProxyInputPort<Integer> mIn = new ProxyInputPort<>();
+    @OutputPortFieldAnnotation(optional = true)
+    public transient final ProxyOutputPort<Integer> mOut = new ProxyOutputPort<>();
+
+    @Override
+    public void populateDAG(DAG dag, Configuration conf)
+    {
+      DummyOperator o1 = dag.addOperator("O1", new DummyOperator());
+      o1.setOperatorProp(level1ModuleProp);
+      mIn.set(o1.in);
+      mOut.set(o1.out1);
+    }
+
+    public int getLevel1ModuleProp()
+    {
+      return level1ModuleProp;
+    }
+
+    public void setLevel1ModuleProp(int level1ModuleProp)
+    {
+      this.level1ModuleProp = level1ModuleProp;
+    }
+  }
+
+  static class Level2ModuleA implements Module
+  {
+    private int level2ModuleAProp1 = 0;
+    private int level2ModuleAProp2 = 0;
+    private int level2ModuleAProp3 = 0;
+
+    @InputPortFieldAnnotation(optional = true)
+    public transient final ProxyInputPort<Integer> mIn = new ProxyInputPort<>();
+
+    @OutputPortFieldAnnotation(optional = true)
+    public transient final ProxyOutputPort<Integer> mOut1 = new ProxyOutputPort<>();
+
+    @OutputPortFieldAnnotation(optional = true)
+    public transient final ProxyOutputPort<Integer> mOut2 = new ProxyOutputPort<>();
+
+    @Override
+    public void populateDAG(DAG dag, Configuration conf)
+    {
+      Level1Module m1 = dag.addModule("M1", new Level1Module());
+      m1.setLevel1ModuleProp(level2ModuleAProp1);
+
+      Level1Module m2 = dag.addModule("M2", new Level1Module());
+      m2.setLevel1ModuleProp(level2ModuleAProp2);
+
+      DummyOperator o1 = dag.addOperator("O1", new DummyOperator());
+      o1.setOperatorProp(level2ModuleAProp3);
+
+      dag.addStream("M1_M2&O1", m1.mOut, m2.mIn, o1.in);
+
+      mIn.set(m1.mIn);
+      mOut1.set(m2.mOut);
+      mOut2.set(o1.out1);
+    }
+
+    public int getLevel2ModuleAProp1()
+    {
+      return level2ModuleAProp1;
+    }
+
+    public void setLevel2ModuleAProp1(int level2ModuleAProp1)
+    {
+      this.level2ModuleAProp1 = level2ModuleAProp1;
+    }
+
+    public int getLevel2ModuleAProp2()
+    {
+      return level2ModuleAProp2;
+    }
+
+    public void setLevel2ModuleAProp2(int level2ModuleAProp2)
+    {
+      this.level2ModuleAProp2 = level2ModuleAProp2;
+    }
+
+    public int getLevel2ModuleAProp3()
+    {
+      return level2ModuleAProp3;
+    }
+
+    public void setLevel2ModuleAProp3(int level2ModuleAProp3)
+    {
+      this.level2ModuleAProp3 = level2ModuleAProp3;
+    }
+  }
+
+  static class Level2ModuleB implements Module
+  {
+    private int level2ModuleBProp1 = 0;
+    private int level2ModuleBProp2 = 0;
+    private int level2ModuleBProp3 = 0;
+
+    @InputPortFieldAnnotation(optional = true)
+    public transient final ProxyInputPort<Integer> mIn = new ProxyInputPort<>();
+
+    @OutputPortFieldAnnotation(optional = true)
+    public transient final ProxyOutputPort<Integer> mOut1 = new ProxyOutputPort<>();
+
+    @OutputPortFieldAnnotation(optional = true)
+    public transient final ProxyOutputPort<Integer> mOut2 = new ProxyOutputPort<>();
+
+    @Override
+    public void populateDAG(DAG dag, Configuration conf)
+    {
+      DummyOperator o1 = dag.addOperator("O1", new DummyOperator());
+      o1.setOperatorProp(level2ModuleBProp1);
+
+      Level1Module m1 = dag.addModule("M1", new Level1Module());
+      m1.setLevel1ModuleProp(level2ModuleBProp2);
+
+      DummyOperator o2 = dag.addOperator("O2", new DummyOperator());
+      o2.setOperatorProp(level2ModuleBProp3);
+
+      dag.addStream("O1_M1", o1.out1, m1.mIn);
+      dag.addStream("O1_O2", o1.out2, o2.in);
+
+      mIn.set(o1.in);
+      mOut1.set(m1.mOut);
+      mOut2.set(o2.out1);
+    }
+
+    public int getLevel2ModuleBProp1()
+    {
+      return level2ModuleBProp1;
+    }
+
+    public void setLevel2ModuleBProp1(int level2ModuleBProp1)
+    {
+      this.level2ModuleBProp1 = level2ModuleBProp1;
+    }
+
+    public int getLevel2ModuleBProp2()
+    {
+      return level2ModuleBProp2;
+    }
+
+    public void setLevel2ModuleBProp2(int level2ModuleBProp2)
+    {
+      this.level2ModuleBProp2 = level2ModuleBProp2;
+    }
+
+    public int getLevel2ModuleBProp3()
+    {
+      return level2ModuleBProp3;
+    }
+
+    public void setLevel2ModuleBProp3(int level2ModuleBProp3)
+    {
+      this.level2ModuleBProp3 = level2ModuleBProp3;
+    }
+  }
+
+  static class Level3Module implements Module {
+
+    public transient final ProxyInputPort<Integer> mIn = new ProxyInputPort<>();
+    public transient final ProxyOutputPort<Integer> mOut1 = new ProxyOutputPort<>();
+    public transient final ProxyOutputPort<Integer> mOut2 = new ProxyOutputPort<>();
+
+    @Override
+    public void populateDAG(DAG dag, Configuration conf)
+    {
+      DummyOperator op = dag.addOperator("O1", new DummyOperator());
+      Level2ModuleB m1 = dag.addModule("M1", new Level2ModuleB());
+      Level1Module m2 = dag.addModule("M2", new Level1Module());
+
+      dag.addStream("s1", op.out1, m1.mIn);
+      dag.addStream("s2", op.out2, m2.mIn);
+
+      mIn.set(op.in);
+      mOut1.set(m1.mOut1);
+      mOut2.set(m2.mOut);
+    }
+  }
+
+  static class NestedModuleApp implements StreamingApplication
+  {
+    @Override
+    public void populateDAG(DAG dag, Configuration conf)
+    {
+      DummyInputOperator o1 = dag.addOperator("O1", new DummyInputOperator());
+      o1.setInputOperatorProp(1);
+
+      DummyOperator o2 = dag.addOperator("O2", new DummyOperator());
+      o2.setOperatorProp(2);
+
+      Level2ModuleA ma = dag.addModule("Ma", new Level2ModuleA());
+      ma.setLevel2ModuleAProp1(11);
+      ma.setLevel2ModuleAProp2(12);
+      ma.setLevel2ModuleAProp3(13);
+
+      Level2ModuleB mb = dag.addModule("Mb", new Level2ModuleB());
+      mb.setLevel2ModuleBProp1(21);
+      mb.setLevel2ModuleBProp2(22);
+      mb.setLevel2ModuleBProp3(23);
+
+      Level2ModuleA mc = dag.addModule("Mc", new Level2ModuleA());
+      mc.setLevel2ModuleAProp1(31);
+      mc.setLevel2ModuleAProp2(32);
+      mc.setLevel2ModuleAProp3(33);
+
+      Level2ModuleB md = dag.addModule("Md", new Level2ModuleB());
+      md.setLevel2ModuleBProp1(41);
+      md.setLevel2ModuleBProp2(42);
+      md.setLevel2ModuleBProp3(43);
+
+      Level3Module me = dag.addModule("Me", new Level3Module());
+
+      dag.addStream("O1_O2", o1.out, o2.in, me.mIn);
+      dag.addStream("O2_Ma", o2.out1, ma.mIn);
+      dag.addStream("Ma_Mb", ma.mOut1, mb.mIn);
+      dag.addStream("Ma_Md", ma.mOut2, md.mIn);
+      dag.addStream("Mb_Mc", mb.mOut2, mc.mIn);
+    }
+  }
+
+  @Test
+  public void testModuleExtreme()
+  {
+    StreamingApplication app = new NestedModuleApp();
+    Configuration conf = new Configuration(false);
+    LogicalPlanConfiguration lpc = new LogicalPlanConfiguration(conf);
+    LogicalPlan dag = new LogicalPlan();
+    lpc.prepareDAG(dag, app, "ModuleApp");
+
+    dag.validate();
+    validateTopLevelOperators(dag);
+    validateTopLevelStreams(dag);
+    validatePublicMethods(dag);
+  }
+
+  private void validateTopLevelStreams(LogicalPlan dag)
+  {
+    List<String> streamNames = new ArrayList<>();
+    for (LogicalPlan.StreamMeta streamMeta : dag.getAllStreams()) {
+      streamNames.add(streamMeta.getName());
+    }
+
+    Assert.assertTrue(streamNames.contains(componentName("Mb", "O1_M1")));
+    Assert.assertTrue(streamNames.contains("O2_Ma"));
+    Assert.assertTrue(streamNames.contains("Mb_Mc"));
+    Assert.assertTrue(streamNames.contains(componentName("Mb", "O1_O2")));
+    Assert.assertTrue(streamNames.contains(componentName("Ma", "M1_M2&O1")));
+    Assert.assertTrue(streamNames.contains(componentName("Md", "O1_M1")));
+    Assert.assertTrue(streamNames.contains(componentName("Ma_Md")));
+    Assert.assertTrue(streamNames.contains(componentName("Mc", "M1_M2&O1")));
+    Assert.assertTrue(streamNames.contains(componentName("Md", "O1_O2")));
+    Assert.assertTrue(streamNames.contains("Ma_Mb"));
+    Assert.assertTrue(streamNames.contains("O1_O2"));
+
+    validateSeperateStream(dag, componentName("Mb", "O1_M1"), componentName("Mb", "O1"), componentName("Mb", "M1", "O1"));
+    validateSeperateStream(dag, "O2_Ma", "O2", componentName("Ma", "M1", "O1"));
+    validateSeperateStream(dag, "Mb_Mc", componentName("Mb", "O2"), componentName("Mc", "M1", "O1"));
+    validateSeperateStream(dag, componentName("Mb", "O1_O2"), componentName("Mb", "O1"), componentName("Mb", "O2"));
+    validateSeperateStream(dag, componentName("Ma", "M1_M2&O1"), componentName("Ma", "M1", "O1"), componentName("Ma", "O1"),
+      componentName("Ma", "M2", "O1"));
+    validateSeperateStream(dag, componentName("Md", "O1_M1"), componentName("Md", "O1"), componentName("Md", "M1", "O1"));
+    validateSeperateStream(dag, "Ma_Md", componentName("Ma", "O1"), componentName("Md", "O1"));
+    validateSeperateStream(dag, componentName("Mc", "M1_M2&O1"), componentName("Mc", "M1", "O1"), componentName("Mc", "O1"),
+      componentName("Mc", "M2", "O1"));
+    validateSeperateStream(dag, componentName("Md", "O1_O2"), componentName("Md", "O1"), componentName("Md","O2"));
+    validateSeperateStream(dag, "Ma_Mb", componentName("Ma", "M2", "O1"), componentName("Mb","O1"));
+    validateSeperateStream(dag, "O1_O2", "O1", "O2", componentName("Me", "O1"));
+  }
+
+  private void validateSeperateStream(LogicalPlan dag, String streamName, String inputOperatorName, String... outputOperatorNames)
+  {
+    LogicalPlan.StreamMeta streamMeta = dag.getStream(streamName);
+    String sourceName = streamMeta.getSource().getOperatorMeta().getName();
+
+    List<String> sinksName = new ArrayList<>();
+    for (LogicalPlan.InputPortMeta inputPortMeta : streamMeta.getSinks()) {
+      sinksName.add(inputPortMeta.getOperatorWrapper().getName());
+    }
+
+    Assert.assertTrue(inputOperatorName.equals(sourceName));
+    Assert.assertEquals(outputOperatorNames.length, sinksName.size());
+
+    for (String outputOperatorName : outputOperatorNames) {
+      Assert.assertTrue(sinksName.contains(outputOperatorName));
+    }
+  }
+
+  private void validateTopLevelOperators(LogicalPlan dag)
+  {
+    List<String> operatorNames = new ArrayList<>();
+    for (LogicalPlan.OperatorMeta operatorMeta : dag.getAllOperators()) {
+      operatorNames.add(operatorMeta.getName());
+    }
+    Assert.assertTrue(operatorNames.contains("O1"));
+    Assert.assertTrue(operatorNames.contains("O2"));
+    Assert.assertTrue(operatorNames.contains(componentName("Ma", "M1", "O1")));
+    Assert.assertTrue(operatorNames.contains(componentName("Ma", "M2", "O1")));
+    Assert.assertTrue(operatorNames.contains(componentName("Ma","O1")));
+    Assert.assertTrue(operatorNames.contains(componentName("Mb","O1")));
+    Assert.assertTrue(operatorNames.contains(componentName("Mb", "M1", "O1")));
+    Assert.assertTrue(operatorNames.contains(componentName("Mb", "O2")));
+    Assert.assertTrue(operatorNames.contains(componentName("Mc", "M1", "O1")));
+    Assert.assertTrue(operatorNames.contains(componentName("Mc", "M2", "O1")));
+    Assert.assertTrue(operatorNames.contains(componentName("Mc", "O1")));
+    Assert.assertTrue(operatorNames.contains(componentName("Md", "O1")));
+    Assert.assertTrue(operatorNames.contains(componentName("Md", "M1", "O1")));
+    Assert.assertTrue(operatorNames.contains(componentName("Md", "O2")));
+
+    validateOperatorPropertyValue(dag, "O1", 1);
+    validateOperatorPropertyValue(dag, "O2", 2);
+    validateOperatorPropertyValue(dag, componentName("Ma", "M1", "O1"), 11);
+    validateOperatorPropertyValue(dag, componentName("Ma", "M2", "O1"), 12);
+    validateOperatorPropertyValue(dag, componentName("Ma", "O1"), 13);
+    validateOperatorPropertyValue(dag, componentName("Mb", "O1"), 21);
+    validateOperatorPropertyValue(dag, componentName("Mb", "M1", "O1"), 22);
+    validateOperatorPropertyValue(dag, componentName("Mb", "O2"), 23);
+    validateOperatorPropertyValue(dag, componentName("Mc", "M1", "O1"), 31);
+    validateOperatorPropertyValue(dag, componentName("Mc", "M2", "O1"), 32);
+    validateOperatorPropertyValue(dag, componentName("Mc", "O1"), 33);
+    validateOperatorPropertyValue(dag, componentName("Md", "O1"), 41);
+    validateOperatorPropertyValue(dag, componentName("Md", "M1", "O1"), 42);
+    validateOperatorPropertyValue(dag, componentName("Md", "O2"), 43);
+
+    validateOperatorParent(dag, "O1", null);
+    validateOperatorParent(dag, "O2", null);
+    validateOperatorParent(dag, componentName("Ma", "M1", "O1"), componentName("Ma", "M1"));
+    validateOperatorParent(dag, componentName("Ma", "M2", "O1"), componentName("Ma", "M2"));
+    validateOperatorParent(dag, componentName("Ma", "O1"), "Ma");
+    validateOperatorParent(dag, componentName("Mb", "O1"), "Mb");
+    validateOperatorParent(dag, componentName("Mb", "M1", "O1"), componentName("Mb", "M1"));
+    validateOperatorParent(dag, componentName("Mb", "O2"), "Mb");
+    validateOperatorParent(dag, componentName("Mc", "M1", "O1"), componentName("Mc", "M1"));
+    validateOperatorParent(dag, componentName("Mc", "M2", "O1"), componentName("Mc", "M2"));
+    validateOperatorParent(dag, componentName("Mc", "O1"), "Mc");
+    validateOperatorParent(dag, componentName("Md", "O1"), "Md");
+    validateOperatorParent(dag, componentName("Md", "M1", "O1"), componentName("Md", "M1"));
+    validateOperatorParent(dag, componentName("Md", "O2"), "Md");
+  }
+
+  private void validateOperatorParent(LogicalPlan dag, String operatorName, String parentModuleName)
+  {
+    LogicalPlan.OperatorMeta operatorMeta = dag.getOperatorMeta(operatorName);
+    if (parentModuleName == null) {
+      Assert.assertNull(operatorMeta.getModuleName());
+    } else {
+      Assert.assertTrue(parentModuleName.equals(operatorMeta.getModuleName()));
+    }
+  }
+
+  private void validateOperatorPropertyValue(LogicalPlan dag, String operatorName, int expectedValue)
+  {
+    LogicalPlan.OperatorMeta oMeta = dag.getOperatorMeta(operatorName);
+    if (operatorName.equals("O1")) {
+      DummyInputOperator operator = (DummyInputOperator)oMeta.getOperator();
+      Assert.assertEquals(expectedValue, operator.getInputOperatorProp());
+    } else {
+      DummyOperator operator = (DummyOperator)oMeta.getOperator();
+      Assert.assertEquals(expectedValue, operator.getOperatorProp());
+    }
+  }
+
+  private void validatePublicMethods(LogicalPlan dag) {
+    // Logical dag contains 4 modules added on top level.
+    List<String> moduleNames = new ArrayList<>();
+    for (LogicalPlan.ModuleMeta moduleMeta: dag.getAllModules()) {
+      moduleNames.add(moduleMeta.getName());
+    }
+    Assert.assertTrue(moduleNames.contains("Ma"));
+    Assert.assertTrue(moduleNames.contains("Mb"));
+    Assert.assertTrue(moduleNames.contains("Mc"));
+    Assert.assertTrue(moduleNames.contains("Md"));
+    Assert.assertTrue(moduleNames.contains("Me"));
+    Assert.assertEquals("Number of modules are 5", 5, dag.getAllModules().size());
+
+    // correct module meta is returned by getMeta call.
+    LogicalPlan.ModuleMeta m = dag.getModuleMeta("Ma");
+    Assert.assertEquals("Name of module is Ma", m.getName(), "Ma");
+
+
+  }
+
+  private static String componentName(String... names) {
+    if (names.length == 0) return "";
+    StringBuilder sb = new StringBuilder(names[0]);
+    for(int i = 1; i < names.length; i++) {
+      sb.append(LogicalPlan.MODULE_NAMESPACE_SEPARATOR);
+      sb.append(names[i]);
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Generate a conflict, Add a top level operator with name "m1_O1",
+   * and add a module "m1" which will populate operator "O1", causing name conflict with
+   * top level operator.
+   */
+  @Test(expected = java.lang.IllegalArgumentException.class )
+  public void conflictingNamesWithExpandedModule() {
+    Configuration conf = new Configuration(false);
+    LogicalPlanConfiguration lpc = new LogicalPlanConfiguration(conf);
+    LogicalPlan dag = new LogicalPlan();
+    DummyInputOperator in = dag.addOperator(componentName("m1", "O1"), new DummyInputOperator());
+    Level2ModuleA module = dag.addModule("m1", new Level2ModuleA());
+    dag.addStream("s1", in.out, module.mIn);
+    lpc.prepareDAG(dag, null, "ModuleApp");
+    dag.validate();
+  }
+
+  /**
+   * Module and Operator with same name is not allowed in a DAG, to prevent properties
+   * conflict.
+   */
+  @Test(expected = java.lang.IllegalArgumentException.class )
+  public void conflictingNamesWithOperator1() {
+    Configuration conf = new Configuration(false);
+    LogicalPlanConfiguration lpc = new LogicalPlanConfiguration(conf);
+    LogicalPlan dag = new LogicalPlan();
+    DummyInputOperator in = dag.addOperator("M1", new DummyInputOperator());
+    Level2ModuleA module = dag.addModule("M1", new Level2ModuleA());
+    dag.addStream("s1", in.out, module.mIn);
+    lpc.prepareDAG(dag, null, "ModuleApp");
+    dag.validate();
+  }
+
+  /**
+   * Module and Operator with same name is not allowed in a DAG, to prevent properties
+   * conflict.
+   */
+  @Test(expected = java.lang.IllegalArgumentException.class )
+  public void conflictingNamesWithOperator2() {
+    Configuration conf = new Configuration(false);
+    LogicalPlanConfiguration lpc = new LogicalPlanConfiguration(conf);
+    LogicalPlan dag = new LogicalPlan();
+    Level2ModuleA module = dag.addModule("M1", new Level2ModuleA());
+    DummyInputOperator in = dag.addOperator("M1", new DummyInputOperator());
+    dag.addStream("s1", in.out, module.mIn);
+    lpc.prepareDAG(dag, null, "ModuleApp");
+    dag.validate();
+  }
+}

--- a/engine/src/test/java/com/datatorrent/stram/plan/logical/module/TestModuleProperties.java
+++ b/engine/src/test/java/com/datatorrent/stram/plan/logical/module/TestModuleProperties.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.datatorrent.stram.plan.logical.module;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.apache.hadoop.conf.Configuration;
+
+import com.datatorrent.api.StreamingApplication;
+import com.datatorrent.stram.plan.logical.LogicalPlan;
+import com.datatorrent.stram.plan.logical.LogicalPlanConfiguration;
+
+public class TestModuleProperties
+{
+  @Test
+  public void testModuleProperties()
+  {
+    Configuration conf = new Configuration(false);
+    conf.set(StreamingApplication.DT_PREFIX + "operator.o1.prop.myStringProperty", "myStringPropertyValue");
+    conf.set(StreamingApplication.DT_PREFIX + "operator.o2.prop.stringArrayField", "a,b,c");
+    conf.set(StreamingApplication.DT_PREFIX + "operator.o2.prop.mapProperty.key1", "key1Val");
+    conf.set(StreamingApplication.DT_PREFIX + "operator.o2.prop.mapProperty(key1.dot)", "key1dotVal");
+    conf.set(StreamingApplication.DT_PREFIX + "operator.o2.prop.mapProperty(key2.dot)", "key2dotVal");
+
+    LogicalPlan dag = new LogicalPlan();
+    TestModules.GenericModule o1 = dag.addModule("o1", new TestModules.GenericModule());
+    //LogicalPlanTest.ValidationTestOperator o2 = dag.addOperator("o2", new LogicalPlanTest.ValidationTestOperator());
+    TestModules.ValidationTestModule o2 = dag.addModule("o2", new TestModules.ValidationTestModule());
+
+    LogicalPlanConfiguration pb = new LogicalPlanConfiguration(conf);
+
+    pb.setModuleProperties(dag, "testSetOperatorProperties");
+    Assert.assertEquals("o1.myStringProperty", "myStringPropertyValue", o1.getMyStringProperty());
+    Assert.assertArrayEquals("o2.stringArrayField", new String[]{"a", "b", "c"}, o2.getStringArrayField());
+
+    Assert.assertEquals("o2.mapProperty.key1", "key1Val", o2.getMapProperty().get("key1"));
+    Assert.assertEquals("o2.mapProperty(key1.dot)", "key1dotVal", o2.getMapProperty().get("key1.dot"));
+    Assert.assertEquals("o2.mapProperty(key2.dot)", "key2dotVal", o2.getMapProperty().get("key2.dot"));
+
+  }
+
+}

--- a/engine/src/test/java/com/datatorrent/stram/plan/logical/module/TestModules.java
+++ b/engine/src/test/java/com/datatorrent/stram/plan/logical/module/TestModules.java
@@ -1,0 +1,216 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.datatorrent.stram.plan.logical.module;
+
+import java.util.Map;
+
+import javax.validation.Valid;
+import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.conf.Configuration;
+
+import com.google.common.collect.Maps;
+
+import com.datatorrent.api.DAG;
+import com.datatorrent.api.DefaultOutputPort;
+import com.datatorrent.api.Module;
+import com.datatorrent.api.annotation.OutputPortFieldAnnotation;
+import com.datatorrent.stram.engine.GenericOperatorProperty;
+
+public class TestModules
+{
+
+  public static class GenericModule implements Module
+  {
+    private static final Logger LOG = LoggerFactory.getLogger(TestModules.class);
+
+    public volatile Object inport1Tuple = null;
+
+    @OutputPortFieldAnnotation(optional = true)
+    final public transient DefaultOutputPort<Object> outport1 = new DefaultOutputPort<Object>();
+
+    @OutputPortFieldAnnotation(optional = true)
+    final public transient DefaultOutputPort<Object> outport2 = new DefaultOutputPort<Object>();
+
+    private String emitFormat;
+
+    public boolean booleanProperty;
+
+    private String myStringProperty;
+
+    private transient GenericOperatorProperty genericOperatorProperty = new GenericOperatorProperty("test");
+
+    public String getMyStringProperty()
+    {
+      return myStringProperty;
+    }
+
+    public void setMyStringProperty(String myStringProperty)
+    {
+      this.myStringProperty = myStringProperty;
+    }
+
+    public boolean isBooleanProperty()
+    {
+      return booleanProperty;
+    }
+
+    public void setBooleanProperty(boolean booleanProperty)
+    {
+      this.booleanProperty = booleanProperty;
+    }
+
+    public String propertySetterOnly;
+
+    /**
+     * setter w/o getter defined
+     *
+     * @param v
+     */
+    public void setStringPropertySetterOnly(String v)
+    {
+      this.propertySetterOnly = v;
+    }
+
+    public String getEmitFormat()
+    {
+      return emitFormat;
+    }
+
+    public void setEmitFormat(String emitFormat)
+    {
+      this.emitFormat = emitFormat;
+    }
+
+    public GenericOperatorProperty getGenericOperatorProperty()
+    {
+      return genericOperatorProperty;
+    }
+
+    public void setGenericOperatorProperty(GenericOperatorProperty genericOperatorProperty)
+    {
+      this.genericOperatorProperty = genericOperatorProperty;
+    }
+
+    @Override
+    public void populateDAG(DAG dag, Configuration conf)
+    {
+      LOG.debug("populateDAG of module called");
+    }
+  }
+
+  public static class ValidationTestModule implements Module
+  {
+    @NotNull
+    @Pattern(regexp = ".*malhar.*", message = "Value has to contain 'malhar'!")
+    private String stringField1;
+
+    @Min(2)
+    private int intField1;
+
+    @AssertTrue(message = "stringField1 should end with intField1")
+    private boolean isValidConfiguration()
+    {
+      return stringField1.endsWith(String.valueOf(intField1));
+    }
+
+    private String getterProperty2 = "";
+
+    @NotNull
+    public String getProperty2()
+    {
+      return getterProperty2;
+    }
+
+    public void setProperty2(String s)
+    {
+      // annotations need to be on the getter
+      getterProperty2 = s;
+    }
+
+    private String[] stringArrayField;
+
+    public String[] getStringArrayField()
+    {
+      return stringArrayField;
+    }
+
+    public void setStringArrayField(String[] stringArrayField)
+    {
+      this.stringArrayField = stringArrayField;
+    }
+
+    public class Nested
+    {
+      @NotNull
+      private String property = "";
+
+      public String getProperty()
+      {
+        return property;
+      }
+
+      public void setProperty(String property)
+      {
+        this.property = property;
+      }
+
+    }
+
+    @Valid
+    private final Nested nestedBean = new Nested();
+
+    private String stringProperty2;
+
+    public String getStringProperty2()
+    {
+      return stringProperty2;
+    }
+
+    public void setStringProperty2(String stringProperty2)
+    {
+      this.stringProperty2 = stringProperty2;
+    }
+
+    private Map<String, String> mapProperty = Maps.newHashMap();
+
+    public Map<String, String> getMapProperty()
+    {
+      return mapProperty;
+    }
+
+    public void setMapProperty(Map<String, String> mapProperty)
+    {
+      this.mapProperty = mapProperty;
+    }
+
+    @Override
+    public void populateDAG(DAG dag, Configuration conf)
+    {
+
+    }
+  }
+
+}


### PR DESCRIPTION
- Added module interface and module meta.
- Expanding DAG at logical plan level.
- Exposing of properties of module and setting module properties from DAG.
- Added references of parent module meta in operator, stream and module meta.
- Added proxy ports for using in Modules.
- Added REST APIs for modules for logicalPlan and also corresponding dtcli changes.
- Added Test application for Module having all aboe fetures.
- Added unit tests for properties, module expansion, and connecting streams.

@vrozov , @tweise , @PramodSSImmaneni , @sandeepdeshmukh : Please review
