### PR TITLE
APEXCORE-305 - Enable checkstyle violations logging to console during maven build

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -70,9 +70,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <configuration>
-          <logViolationsToConsole>true</logViolationsToConsole>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/bufferserver/pom.xml
+++ b/bufferserver/pom.xml
@@ -48,10 +48,8 @@
       </plugin>
       -->
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <configuration>
-          <consoleOutput>true</consoleOutput>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -55,9 +55,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <configuration>
-          <logViolationsToConsole>true</logViolationsToConsole>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -33,6 +33,10 @@
 
   <name>Apache Apex (incubating) Stream Processing Engine</name>
 
+  <properties>
+    <checkstyle.console>false</checkstyle.console>
+  </properties>
+
   <build>
     <finalName>${project.artifactId}</finalName>
     <plugins>
@@ -146,6 +150,7 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <configuration>
           <maxAllowedViolations>3224</maxAllowedViolations>
+          <logViolationsToConsole>${checkstyle.console}</logViolationsToConsole>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@
     <!-- do not change jetty version as later versions have problems with DefaultServlet -->
     <jetty.version>8.1.10.v20130312</jetty.version>
     <license.skip>true</license.skip>
-    <checkstyle.console>false</checkstyle.console>
     <postNoticeText>The initial developer of the original code is&#xA;DataTorrent, Inc. (http://www.datatorrent.com)&#xA;Copyright (c) 2012 - 2015. All Rights Reserved.</postNoticeText>
   </properties>
 
@@ -316,16 +315,11 @@
               <goals>
                 <goal>check</goal>
               </goals>
-              <configuration>
-                <failOnViolation>true</failOnViolation>
-                <logViolationsToConsole>${checkstyle.console}</logViolationsToConsole>
-              </configuration>
             </execution>
           </executions>
           <configuration>
             <configLocation>apex_checks.xml</configLocation>
             <suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
-            <suppressionsFileExpression>checkstyle.suppressions.file</suppressionsFileExpression>
             <includeTestSourceDirectory>true</includeTestSourceDirectory>
           </configuration>
         </plugin>


### PR DESCRIPTION
@tweise @chandnisingh Please review. The change unifies logging for `mvn verify` and `mvn checkstyle:check` and logs only currently enabled violations.
