### PR TITLE
APEXCORE-107 Allow adding module in DAG specified by property file and json

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/StramUtils.java
+++ b/engine/src/main/java/com/datatorrent/stram/StramUtils.java
@@ -46,6 +46,16 @@ public abstract class StramUtils
     }
   }
 
+  public static Class<?> classForName(String className)
+  {
+    try {
+      return Thread.currentThread().getContextClassLoader().loadClass(className);
+    }
+    catch (ClassNotFoundException e) {
+      throw new IllegalArgumentException("Class not found: " + className, e);
+    }
+  }
+
   public static <T> T newInstance(Class<T> clazz)
   {
     try {

--- a/engine/src/main/java/com/datatorrent/stram/plan/logical/Operators.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/logical/Operators.java
@@ -18,6 +18,7 @@
  */
 package com.datatorrent.stram.plan.logical;
 
+import com.datatorrent.api.Module;
 import com.datatorrent.common.experimental.AppData;
 import com.datatorrent.api.Context.PortContext;
 import com.datatorrent.api.Operator;
@@ -80,8 +81,13 @@ public abstract class Operators
     }
   };
 
-  public static void describe(Operator operator, OperatorDescriptor descriptor)
+  public static void describe(Object operator, OperatorDescriptor descriptor)
   {
+    if (!(Operator.class.isAssignableFrom(operator.getClass()) ||
+      Module.class.isAssignableFrom(operator.getClass()))) {
+      throw new IllegalArgumentException("Object should be module or operator");
+    }
+
     for (Class<?> c = operator.getClass(); c != Object.class; c = c.getSuperclass())
     {
       Field[] fields = c.getDeclaredFields();

--- a/engine/src/test/resources/testModuleTopology.json
+++ b/engine/src/test/resources/testModuleTopology.json
@@ -1,0 +1,141 @@
+{
+  "operators": [
+    {
+      "name": "O1",
+      "class": "com.datatorrent.stram.plan.logical.module.TestModuleExpansion$DummyInputOperator",
+      "properties": {
+        "com.datatorrent.stram.plan.logical.module.TestModuleExpansion$DummyInputOperator": {
+          "inputOperatorProp": "1"
+        }
+      }
+    },
+    {
+      "name": "O2",
+      "class": "com.datatorrent.stram.plan.logical.module.TestModuleExpansion$DummyOperator",
+      "properties": {
+        "com.datatorrent.stram.plan.logical.module.TestModuleExpansion$DummyOperator": {
+          "operatorProp": "2"
+        }
+      }
+    },
+    {
+      "name": "Ma",
+      "class": "com.datatorrent.stram.plan.logical.module.TestModuleExpansion$Level2ModuleA",
+      "properties": {
+        "com.datatorrent.stram.plan.logical.module.TestModuleExpansion$Level2ModuleA": {
+          "level2ModuleAProp1": "11",
+          "level2ModuleAProp2": "12",
+          "level2ModuleAProp3": "13"
+        }
+      }
+    },
+    {
+      "name": "Mb",
+      "class": "com.datatorrent.stram.plan.logical.module.TestModuleExpansion$Level2ModuleB",
+      "properties": {
+        "com.datatorrent.stram.plan.logical.module.TestModuleExpansion$Level2ModuleB": {
+          "level2ModuleBProp1": "21",
+          "level2ModuleBProp2": "22",
+          "level2ModuleBProp3": "23"
+        }
+      }
+    },
+    {
+      "name": "Mc",
+      "class": "com.datatorrent.stram.plan.logical.module.TestModuleExpansion$Level2ModuleA",
+      "properties": {
+        "com.datatorrent.stram.plan.logical.module.TestModuleExpansion$Level2ModuleA": {
+          "level2ModuleAProp1": "31",
+          "level2ModuleAProp2": "32",
+          "level2ModuleAProp3": "33"
+        }
+      }
+    },
+    {
+      "name": "Md",
+      "class": "com.datatorrent.stram.plan.logical.module.TestModuleExpansion$Level2ModuleB",
+      "properties": {
+        "com.datatorrent.stram.plan.logical.module.TestModuleExpansion$Level2ModuleB": {
+          "level2ModuleBProp1": "41",
+          "level2ModuleBProp2": "42",
+          "level2ModuleBProp3": "43"
+        }
+      }
+    },
+    {
+      "name": "Me",
+      "class": "com.datatorrent.stram.plan.logical.module.TestModuleExpansion$Level3Module"
+    }
+  ],
+  "streams": [
+    {
+      "name": "O1_O2",
+      "source": {
+        "operatorName": "O1",
+        "portName": "out"
+      },
+      "sinks": [
+        {
+          "operatorName": "O2",
+          "portName": "in"
+        },
+        {
+          "operatorName": "Me",
+          "portName": "mIn"
+        }
+      ]
+    },
+    {
+      "name": "O2_Ma",
+      "source": {
+        "operatorName": "O2",
+        "portName": "out1"
+      },
+      "sinks": [
+        {
+          "operatorName": "Ma",
+          "portName": "mIn"
+        }
+      ]
+    },
+    {
+      "name": "Ma_Mb",
+      "source": {
+        "operatorName": "Ma",
+        "portName": "mOut1"
+      },
+      "sinks": [
+        {
+          "operatorName": "Mb",
+          "portName": "mIn"
+        }
+      ]
+    },
+    {
+      "name": "Ma_Md",
+      "source": {
+        "operatorName": "Ma",
+        "portName": "mOut2"
+      },
+      "sinks": [
+        {
+          "operatorName": "Md",
+          "portName": "mIn"
+        }
+      ]
+    },
+    {
+      "name": "Mb_Mc",
+      "source": {
+        "operatorName": "Mb",
+        "portName": "mOut2"
+      },
+      "sinks": [
+        {
+          "operatorName": "Mc",
+          "portName": "mIn"
+        }
+      ]
+    }
+  ]
+}

--- a/engine/src/test/resources/testModuleTopology.properties
+++ b/engine/src/test/resources/testModuleTopology.properties
@@ -1,0 +1,62 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# test for defining topology as property file
+dt.operator.O1.classname=com.datatorrent.stram.plan.logical.module.TestModuleExpansion$DummyInputOperator
+dt.operator.O1.inputOperatorProp=1
+
+dt.operator.O2.classname=com.datatorrent.stram.plan.logical.module.TestModuleExpansion$DummyOperator
+dt.operator.O2.operatorProp=2
+
+dt.operator.Ma.classname=com.datatorrent.stram.plan.logical.module.TestModuleExpansion$Level2ModuleA
+dt.operator.Ma.level2ModuleAProp1=11
+dt.operator.Ma.level2ModuleAProp2=12
+dt.operator.Ma.level2ModuleAProp3=13
+
+dt.operator.Mb.classname=com.datatorrent.stram.plan.logical.module.TestModuleExpansion$Level2ModuleB
+dt.operator.Mb.level2ModuleBProp1=21
+dt.operator.Mb.level2ModuleBProp2=22
+dt.operator.Mb.level2ModuleBProp3=23
+
+dt.operator.Mc.classname=com.datatorrent.stram.plan.logical.module.TestModuleExpansion$Level2ModuleA
+dt.operator.Mc.level2ModuleAProp1=31
+dt.operator.Mc.level2ModuleAProp2=32
+dt.operator.Mc.level2ModuleAProp3=33
+
+dt.operator.Md.classname=com.datatorrent.stram.plan.logical.module.TestModuleExpansion$Level2ModuleB
+dt.operator.Md.level2ModuleBProp1=41
+dt.operator.Md.level2ModuleBProp2=42
+dt.operator.Md.level2ModuleBProp3=43
+
+dt.operator.Me.classname=com.datatorrent.stram.plan.logical.module.TestModuleExpansion$Level3Module
+
+dt.stream.O1_O2.source=O1.out
+dt.stream.O1_O2.sinks=O2.in,Me.mIn
+
+dt.stream.O2_Ma.source=O2.out1
+dt.stream.O2_Ma.sinks=Ma.mIn
+
+dt.stream.Ma_Mb.source=Ma.mOut1
+dt.stream.Ma_Mb.sinks=Mb.mIn
+
+dt.stream.Ma_Md.source=Ma.mOut2
+dt.stream.Ma_Md.sinks=Md.mIn
+
+dt.stream.Mb_Mc.source=Mb.mOut2
+dt.stream.Mb_Mc.sinks=Mc.mIn


### PR DESCRIPTION
Changes in this pull request
- setSource, addSink were not handling module proxy port, made this work.
- cleanup proxy port clean up logic.
- created common base class for OperatorMeta and ModuleMeta which will keep information for ports as this functionality is common between modules and operators.
- Allow modules to be used while specifying DAG in property file.
