### PR TITLE
(Only for Review) APEXCORE-10 Changes for supporting anti-affinity in operators

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -84,14 +84,6 @@
           <groupId>commons-beanutils</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>jackson-core-asl</artifactId>
-          <groupId>org.codehaus.jackson</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>jackson-mapper-asl</artifactId>
-          <groupId>org.codehaus.jackson</groupId>
-        </exclusion>
-        <exclusion>
           <artifactId>jackson-jaxrs</artifactId>
           <groupId>org.codehaus.jackson</groupId>
         </exclusion>

--- a/api/src/main/java/com/datatorrent/api/AffinityRule.java
+++ b/api/src/main/java/com/datatorrent/api/AffinityRule.java
@@ -1,0 +1,211 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.datatorrent.api;
+
+import java.io.Serializable;
+import java.util.List;
+
+import com.datatorrent.api.DAG.Locality;
+
+/**
+ * Affinity rule specifies constraints for physical deployment of operator
+ * containers. There are two types of rules that can be specified: Affinity and
+ * Anti-affinity. Each rule contains list of operators or pair of 2 operators or
+ * a regex that should match at least 2 operators. Based on the type of rule,
+ * affinity or anti-affinity, the operators will be deployed together or away
+ * from each other. The locality indicates the level at which the rule should be
+ * applied. E.g. CONTAINER_LOCAL affinity would indicate operators Should be
+ * allocated within same container NODE_LOCAL anti-affinity indicates that the
+ * operators should not be allocated on the same node. The rule can be either
+ * strict or relaxed.
+ *
+ */
+public class AffinityRule implements Serializable
+{
+  @Override
+  public String toString()
+  {
+    return "AffinityRule {operatorsList=" + operatorsList + ", operatorRegex=" + operatorRegex + ", operators="
+        + operators + ", locality=" + locality + ", type=" + type + ", relaxLocality=" + relaxLocality + "}";
+  }
+
+  private static final long serialVersionUID = 107131504929875386L;
+
+  /**
+   * Pair of operator names to specify affinity rule
+   * The order of operators is not considered in this class
+   * i.e. OperatorPair("O1", "O2") is equal to OperatorPair("O2", "O1")
+   */
+  public static class OperatorPair implements Serializable
+  {
+    @Override
+    public String toString()
+    {
+      return "OperatorPair (first=" + first + ", second=" + second + ")";
+    }
+
+    private static final long serialVersionUID = 4636942499106381268L;
+    public String first;
+    public String second;
+
+    public OperatorPair(String first, String second)
+    {
+      this.first = first;
+      this.second = second;
+    }
+
+    public OperatorPair()
+    {
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+      if (obj instanceof OperatorPair) {
+        OperatorPair pairObj = (OperatorPair)obj;
+        // The pair objects are equal if same 2 operators are present in both pairs
+        // Order does not matter
+        return ((this.first.equals(pairObj.first)) && (this.second.equals(pairObj.second)))
+            || (this.first.equals(pairObj.second) && this.second.equals(pairObj.first));
+      }
+      return super.equals(obj);
+    }
+
+    @Override
+    public int hashCode()
+    {
+      return this.first.hashCode() + this.second.hashCode();
+    }
+  }
+
+  /**
+   * Type of affinity rule setting affects how operators are scheduled for
+   * deployment by the platform.
+   */
+  public static enum Type
+  {
+    /**
+     * AFFINITY indicates that operators in the rule should be deployed within
+     * locality specified in the rule
+     */
+    AFFINITY,
+    /**
+     * ANTI_AFFINITY indicates that operators in the rule should NOT deployed
+     * within same locality as specified in rule
+     */
+    ANTI_AFFINITY
+  }
+
+  private List<String> operatorsList;
+  private String operatorRegex;
+  private OperatorPair operators;
+  private Locality locality;
+  private Type type;
+  private boolean relaxLocality;
+
+  public AffinityRule()
+  {
+  }
+
+  public AffinityRule(Type type, Locality locality, boolean relaxLocality)
+  {
+    this.type = type;
+    this.locality = locality;
+    this.setRelaxLocality(relaxLocality);
+  }
+
+  public AffinityRule(Type type, OperatorPair operatorsPair, Locality locality, boolean relaxLocality)
+  {
+    this(type, locality, relaxLocality);
+    this.operators = operatorsPair;
+  }
+
+  public AffinityRule(Type type, List<String> operatorsList, Locality locality, boolean relaxLocality)
+  {
+    this(type, locality, relaxLocality);
+    this.operatorsList = operatorsList;
+  }
+
+  public AffinityRule(Type type, String operatorRegex, Locality locality, boolean relaxLocality)
+  {
+    this(type, locality, relaxLocality);
+    this.operatorRegex = operatorRegex;
+  }
+
+  public OperatorPair getOperators()
+  {
+    return operators;
+  }
+
+  public void setOperators(OperatorPair operators)
+  {
+    this.operators = operators;
+  }
+
+  public Locality getLocality()
+  {
+    return locality;
+  }
+
+  public void setLocality(Locality locality)
+  {
+    this.locality = locality;
+  }
+
+  public Type getType()
+  {
+    return type;
+  }
+
+  public void setType(Type type)
+  {
+    this.type = type;
+  }
+
+  public boolean isRelaxLocality()
+  {
+    return relaxLocality;
+  }
+
+  public void setRelaxLocality(boolean relaxLocality)
+  {
+    this.relaxLocality = relaxLocality;
+  }
+
+  public List<String> getOperatorsList()
+  {
+    return operatorsList;
+  }
+
+  public void setOperatorsList(List<String> operatorsList)
+  {
+    this.operatorsList = operatorsList;
+  }
+
+  public String getOperatorRegex()
+  {
+    return operatorRegex;
+  }
+
+  public void setOperatorRegex(String operatorRegex)
+  {
+    this.operatorRegex = operatorRegex;
+  }
+
+}

--- a/api/src/main/java/com/datatorrent/api/AffinityRulesSet.java
+++ b/api/src/main/java/com/datatorrent/api/AffinityRulesSet.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.datatorrent.api;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+/**
+ * Wrapper class for containing set of Affinity rules specified for application
+ */
+public class AffinityRulesSet implements Serializable
+{
+  private Collection<AffinityRule> affinityRules;
+  
+  private static final long serialVersionUID = -8393974533796177171L;
+
+  public Collection<AffinityRule> getAffinityRules()
+  {
+    return affinityRules;
+  }
+
+  public void setAffinityRules(Collection<AffinityRule> affinityRules)
+  {
+    this.affinityRules = affinityRules;
+  }
+}

--- a/api/src/main/java/com/datatorrent/api/Context.java
+++ b/api/src/main/java/com/datatorrent/api/Context.java
@@ -28,6 +28,7 @@ import com.datatorrent.api.Operator.ProcessingMode;
 import com.datatorrent.api.StringCodec.Class2String;
 import com.datatorrent.api.StringCodec.Collection2String;
 import com.datatorrent.api.StringCodec.Integer2String;
+import com.datatorrent.api.StringCodec.JsonStringCodec;
 import com.datatorrent.api.StringCodec.Map2String;
 import com.datatorrent.api.StringCodec.Object2String;
 import com.datatorrent.api.StringCodec.String2String;
@@ -469,6 +470,11 @@ public interface Context
      * Only supports string codecs that have a constructor with no arguments
      */
     Attribute<Map<Class<?>, Class<? extends StringCodec<?>>>> STRING_CODECS = new Attribute<Map<Class<?>, Class<? extends StringCodec<?>>>>(new Map2String<Class<?>, Class<? extends StringCodec<?>>>(",", "=", new Class2String<Object>(), new Class2String<StringCodec<?>>()));
+    /**
+     * Affinity rules for specifying affinity and anti-affinity between logical operators
+     */
+    Attribute<AffinityRulesSet> AFFINITY_RULES_SET = new Attribute<AffinityRulesSet>(new JsonStringCodec<AffinityRulesSet>(AffinityRulesSet.class));
+
     @SuppressWarnings(value = "FieldNameHidesFieldInSuperclass")
     long serialVersionUID = AttributeMap.AttributeInitializer.initialize(DAGContext.class);
   }

--- a/api/src/main/java/com/datatorrent/api/DAG.java
+++ b/api/src/main/java/com/datatorrent/api/DAG.java
@@ -250,6 +250,24 @@ public interface DAG extends DAGContext, Serializable
   public abstract <T> void setAttribute(Operator operator, Attribute<T> key, T value);
 
   /**
+   * Set affinity between operators
+   * @param locality
+   * @param relaxLocality
+   * @param first operator
+   * @param one or more operators
+   */
+  public abstract void setAffinity(Locality locality, boolean relaxLocality, String firstOperator, String... operators);
+
+  /**
+   * Set Anti affinity between operators
+   * @param locality
+   * @param relaxLocality
+   * @param first operator
+   * @param one or more operators
+   */
+  public abstract  void setAntiAffinity(Locality locality, boolean relaxLocality, String firstOperator, String... operators);
+
+  /**
    * <p>setOutputPortAttribute.</p>
    */
   public abstract <T> void setOutputPortAttribute(Operator.OutputPort<?> port, Attribute<T> key, T value);

--- a/api/src/main/java/com/datatorrent/api/StringCodec.java
+++ b/api/src/main/java/com/datatorrent/api/StringCodec.java
@@ -18,12 +18,18 @@
  */
 package com.datatorrent.api;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.codehaus.jackson.map.DeserializationConfig;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.ObjectReader;
+import org.codehaus.jackson.map.ObjectWriter;
 
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.lang.StringUtils;
@@ -377,4 +383,43 @@ public interface StringCodec<T>
     private static final long serialVersionUID = 201312082053L;
   }
 
+  public class JsonStringCodec<T> implements StringCodec<T>, Serializable
+  {
+    private static final long serialVersionUID = 2513932518264776006L;
+    Class<?> clazz;
+
+    public JsonStringCodec(Class<T> clazz)
+    {
+      this.clazz = clazz;
+    }
+
+    @Override
+    public T fromString(String string)
+    {
+      try {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        ObjectReader reader = mapper.reader(clazz);
+        return reader.readValue(string);
+      } catch (IOException e) {
+        DTThrowable.wrapIfChecked(e);
+      }
+      return null;
+    }
+
+    @Override
+    public String toString(T pojo)
+    {
+      try {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        ObjectWriter writer = mapper.writer();
+        return writer.writeValueAsString(pojo);
+      } catch (IOException e) {
+        DTThrowable.wrapIfChecked(e);
+      }
+
+      return null;
+    }
+  }
 }

--- a/engine/src/main/java/com/datatorrent/stram/ContainerRequestHandler.java
+++ b/engine/src/main/java/com/datatorrent/stram/ContainerRequestHandler.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.datatorrent.stram;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.tuple.MutablePair;
+import org.apache.hadoop.yarn.client.api.AMRMClient;
+import org.apache.hadoop.yarn.client.api.AMRMClient.ContainerRequest;
+
+/**
+ * Handles creating container requests and reissuing them on timeout
+ *
+ */
+public class ContainerRequestHandler
+{
+  protected static final int NUMBER_MISSED_HEARTBEATS = 30;
+
+  public void reissueContainerRequests(AMRMClient<ContainerRequest> amRmClient, Map<StreamingContainerAgent.ContainerStartRequest, MutablePair<Integer, ContainerRequest>> requestedResources, int loopCounter, ResourceRequestHandler resourceRequestor, List<ContainerRequest> containerRequests, List<ContainerRequest> removedContainerRequests)
+  {
+    if (!requestedResources.isEmpty()) {
+      // resourceRequestor.clearNodeMapping();
+      for (Map.Entry<StreamingContainerAgent.ContainerStartRequest, MutablePair<Integer, ContainerRequest>> entry : requestedResources.entrySet()) {
+        if ((loopCounter - entry.getValue().getKey()) > NUMBER_MISSED_HEARTBEATS) {
+          StreamingContainerAgent.ContainerStartRequest csr = entry.getKey();
+          removedContainerRequests.add(entry.getValue().getRight());
+          ContainerRequest cr = resourceRequestor.createContainerRequest(csr, false);
+          entry.getValue().setLeft(loopCounter);
+          entry.getValue().setRight(cr);
+          containerRequests.add(cr);
+        }
+      }
+    }
+  }
+
+  public void addContainerRequest(Map<StreamingContainerAgent.ContainerStartRequest, MutablePair<Integer, ContainerRequest>> requestedResources, int loopCounter, List<ContainerRequest> containerRequests, StreamingContainerAgent.ContainerStartRequest csr, ContainerRequest cr)
+  {
+    MutablePair<Integer, ContainerRequest> pair = new MutablePair<Integer, ContainerRequest>(loopCounter, cr);
+    requestedResources.put(csr, pair);
+    containerRequests.add(cr);
+  }
+}

--- a/engine/src/main/java/com/datatorrent/stram/ContainerRequestHandlerCloudera.java
+++ b/engine/src/main/java/com/datatorrent/stram/ContainerRequestHandlerCloudera.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.datatorrent.stram;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.tuple.MutablePair;
+import org.apache.hadoop.yarn.client.api.AMRMClient;
+import org.apache.hadoop.yarn.client.api.AMRMClient.ContainerRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.datatorrent.stram.StreamingContainerAgent.ContainerStartRequest;
+
+/**
+ * Handles creating container requests and issuing node-specific container
+ * requests by blacklisting specifically for cloudera
+ */
+public class ContainerRequestHandlerCloudera extends ContainerRequestHandler
+{
+  HashMap<ContainerRequest, ContainerStartRequest> hostSpecificRequests = new HashMap<>();
+  HashMap<ContainerRequest, ContainerStartRequest> otherContainerRequests = new HashMap<>();
+  HashMap<String, List<ContainerRequest>> hostSpecificRequestsMap = new HashMap<>();
+  List<String> blacklistedNodesForHostSpecificRequests = null;
+
+  public void reissueContainerRequests(AMRMClient<ContainerRequest> amRmClient, Map<StreamingContainerAgent.ContainerStartRequest, MutablePair<Integer, ContainerRequest>> requestedResources, int loopCounter, ResourceRequestHandler resourceRequestor, List<ContainerRequest> containerRequests, List<ContainerRequest> removedContainerRequests)
+  {
+    // Issue all host specific requests first
+    if (!hostSpecificRequestsMap.isEmpty()) {
+      LOG.info("Issue Host specific requests first");
+      // Blacklist all the nodes and issue request for host specific
+      Entry<String, List<ContainerRequest>> set = hostSpecificRequestsMap.entrySet().iterator().next();
+      List<ContainerRequest> requests = set.getValue();
+      List<String> blacklistNodes = resourceRequestor.getNodesExceptHost(requests.get(0).getNodes());
+      amRmClient.updateBlacklist(blacklistNodes, requests.get(0).getNodes());
+      blacklistedNodesForHostSpecificRequests = blacklistNodes;
+      LOG.info("Sending {} request(s) after blacklisting nodes {} and removed host from request {}", requests.size(), blacklistNodes, requests.get(0).getNodes());
+
+      for (ContainerRequest cr : requests) {
+        ContainerStartRequest csr = hostSpecificRequests.get(cr);
+        ContainerRequest newCr = new ContainerRequest(cr.getCapability(), null, null, cr.getPriority());
+        MutablePair<Integer, ContainerRequest> pair = new MutablePair<Integer, ContainerRequest>(loopCounter, newCr);
+        requestedResources.put(csr, pair);
+        containerRequests.add(newCr);
+        hostSpecificRequests.remove(cr);
+      }
+      hostSpecificRequestsMap.remove(set.getKey());
+    } else {
+      if (blacklistedNodesForHostSpecificRequests != null) {
+        // Remove the nodes blacklisted nodes for host specific requests
+        LOG.info("All requests done.. Removing nodes from blacklist {}", blacklistedNodesForHostSpecificRequests);
+        amRmClient.updateBlacklist(null, blacklistedNodesForHostSpecificRequests);
+        blacklistedNodesForHostSpecificRequests = null;
+      }
+      // Proceed with other requests after host specific requests are done
+      if (!otherContainerRequests.isEmpty()) {
+        for (Entry<ContainerRequest, ContainerStartRequest> entry : otherContainerRequests.entrySet()) {
+
+          ContainerRequest cr = entry.getKey();
+          ContainerStartRequest csr = entry.getValue();
+          MutablePair<Integer, ContainerRequest> pair = new MutablePair<Integer, ContainerRequest>(loopCounter, cr);
+          requestedResources.put(csr, pair);
+          containerRequests.add(cr);
+        }
+      } else if (!otherContainerRequests.isEmpty()) {
+        // Check if any requests timed out, create new requests in that case
+        for (Map.Entry<StreamingContainerAgent.ContainerStartRequest, MutablePair<Integer, ContainerRequest>> entry : requestedResources.entrySet()) {
+          if ((loopCounter - entry.getValue().getKey()) > NUMBER_MISSED_HEARTBEATS) {
+            StreamingContainerAgent.ContainerStartRequest csr = entry.getKey();
+            removedContainerRequests.add(entry.getValue().getRight());
+            ContainerRequest cr = resourceRequestor.createContainerRequest(csr, false);
+            if (cr.getNodes() != null && !cr.getNodes().isEmpty()) {
+              addHostSpecificRequest(csr, cr);
+            } else {
+              otherContainerRequests.put(cr, csr);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  public void addContainerRequest(Map<StreamingContainerAgent.ContainerStartRequest, MutablePair<Integer, ContainerRequest>> requestedResources, int loopCounter, List<ContainerRequest> containerRequests, StreamingContainerAgent.ContainerStartRequest csr, ContainerRequest cr)
+  {
+    if (cr.getNodes() != null && !cr.getNodes().isEmpty()) {
+      // Put it in a Map to check if multiple requests can be combined
+      addHostSpecificRequest(csr, cr);
+    } else {
+      LOG.info("No node specific request ", cr);
+      otherContainerRequests.put(cr, csr);
+    }
+  }
+
+  public void addHostSpecificRequest(StreamingContainerAgent.ContainerStartRequest csr, ContainerRequest cr)
+  {
+    String hostKey = StringUtils.join(cr.getNodes(), ":");
+    List<ContainerRequest> requests;
+    if (hostSpecificRequestsMap.containsKey(hostKey)) {
+      requests = hostSpecificRequestsMap.get(hostKey);
+    } else {
+      requests = new ArrayList<>();
+    }
+    requests.add(cr);
+    hostSpecificRequestsMap.put(hostKey, requests);
+    LOG.info("Requesting container for node {} request = {}", cr.getNodes(), cr);
+    hostSpecificRequests.put(cr, csr);
+  }
+
+  private static final Logger LOG = LoggerFactory.getLogger(ContainerRequestHandlerCloudera.class);
+}

--- a/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlan.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlan.java
@@ -26,6 +26,7 @@ import java.lang.reflect.*;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
 
 import javax.validation.*;
 import javax.validation.constraints.NotNull;
@@ -42,8 +43,10 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Sets;
 
 import com.datatorrent.api.*;
+import com.datatorrent.api.AffinityRule.OperatorPair;
 import com.datatorrent.api.Attribute.AttributeMap;
 import com.datatorrent.api.Attribute.AttributeMap.DefaultAttributeMap;
+import com.datatorrent.api.DAG.Locality;
 import com.datatorrent.api.Module.ProxyInputPort;
 import com.datatorrent.api.Module.ProxyOutputPort;
 import com.datatorrent.api.Operator.InputPort;
@@ -1371,6 +1374,50 @@ public class LogicalPlan implements Serializable, DAG
   }
 
   /**
+   * Set affinity between operators
+   */
+  public void setAffinity(Locality locality, boolean relaxLocality, String firstOperator, String... operators)
+  {
+    addRule(com.datatorrent.api.AffinityRule.Type.AFFINITY, locality, relaxLocality, firstOperator, operators);
+  }
+
+  /**
+   * Set Anti affinity between operators
+   */
+  public void setAntiAffinity(Locality locality, boolean relaxLocality, String firstOperator, String... operators)
+  {
+    addRule(com.datatorrent.api.AffinityRule.Type.ANTI_AFFINITY, locality, relaxLocality, firstOperator, operators);
+  }
+
+  private void addRule(com.datatorrent.api.AffinityRule.Type type, Locality locality, boolean relaxLocality, String firstOperator, String... operators)
+  {
+    AffinityRulesSet ruleSet = getAttributes().get(DAGContext.AFFINITY_RULES_SET);
+    if (ruleSet == null) {
+      ruleSet = new AffinityRulesSet();
+      setAttribute(DAGContext.AFFINITY_RULES_SET, ruleSet);
+    }
+    if (ruleSet.getAffinityRules() == null) {
+      Collection<AffinityRule> ruleList = new LinkedList<AffinityRule>();
+      ruleSet.setAffinityRules(ruleList);
+    }
+
+    AffinityRule rule = new AffinityRule(type, locality, relaxLocality);
+    ruleSet.getAffinityRules().add(rule);
+
+    if (operators.length == 1) {
+      rule.setOperators(new OperatorPair(firstOperator, operators[0]));
+    } else {
+      rule.setOperatorsList(new LinkedList<String>());
+      rule.getOperatorsList().add(firstOperator);
+
+      for (String operator : operators) {
+        rule.getOperatorsList().add(operator);
+      }
+    }
+    LOG.debug("Added affinity rule {}", rule);
+  }
+
+  /**
    * This will be called once the Logical Dag is expanded, and the proxy input and proxy output ports are populated with
    * the actual ports that they refer to This method adds sources and sinks for the StreamMeta objects which were left
    * empty in the addStream call.
@@ -1813,6 +1860,167 @@ public class LogicalPlan implements Serializable, DAG
       validateProcessingMode(om, visited);
     }
 
+    validateAffinityRules();
+  }
+
+  private void validateAffinityRules()
+  {
+    AffinityRulesSet affinityRuleSet = getAttributes().get(DAGContext.AFFINITY_RULES_SET);
+    if (affinityRuleSet == null || affinityRuleSet.getAffinityRules() == null) {
+      return;
+    }
+
+    Collection<AffinityRule> affinityRules = affinityRuleSet.getAffinityRules();
+
+    HashMap<OperatorPair, AffinityRule> affinities = new HashMap<>();
+    HashMap<OperatorPair, AffinityRule> threadLocalAffinities = new HashMap<>();
+    HashMap<OperatorPair, AffinityRule> antiAffinities = new HashMap<>();
+
+    List<String> operatorNames = new ArrayList<String>();
+
+    for (OperatorMeta operator : getAllOperators()) {
+      operatorNames.add(operator.getName());
+    }
+
+    Collection<AffinityRule> newAffinityRules = new LinkedList<>();
+    Collection<AffinityRule> removeRules = new LinkedList<>();
+
+    // Identify operators set as Regex and add to list
+    for (AffinityRule rule : affinityRules) {
+      if (rule.getOperatorRegex() != null) {
+        convertRegexToList(operatorNames, rule, removeRules);
+      }
+    }
+    // Convert operators with list of operator to rules with operator pairs for
+    // validation
+    for (AffinityRule rule : affinityRules) {
+      if (rule.getOperatorsList() != null) {
+        List<String> list = rule.getOperatorsList();
+        for (int i = 0; i < list.size(); i++) {
+          for (int j = i + 1; j < list.size(); j++) {
+            OperatorPair pair = new OperatorPair(list.get(i), list.get(j));
+            newAffinityRules.add(new AffinityRule(rule.getType(), pair, rule.getLocality(), rule.isRelaxLocality()));
+          }
+        }
+        removeRules.add(rule);
+      }
+    }
+
+    affinityRules.removeAll(removeRules);
+    affinityRules.addAll(newAffinityRules);
+
+    // Only validate for strict rules
+    for (AffinityRule rule : affinityRules) {
+      if (rule.isRelaxLocality()) {
+        continue;
+      }
+      if (rule.getType() == com.datatorrent.api.AffinityRule.Type.ANTI_AFFINITY) {
+        addToMap(antiAffinities, rule);
+      } else if (rule.getType() == com.datatorrent.api.AffinityRule.Type.AFFINITY) {
+        addToMap(affinities, rule);
+        if (rule.getLocality() == Locality.THREAD_LOCAL) {
+          addToMap(threadLocalAffinities, rule);
+        }
+      }
+    }
+
+    for (Entry<OperatorPair, AffinityRule> entry : antiAffinities.entrySet()) {
+      if (affinities.containsKey(entry.getKey())) {
+        AffinityRule antiRule = entry.getValue();
+        AffinityRule affinityRule = affinities.get(entry.getKey());
+        if (!isValidRules(antiRule, affinityRule.getLocality())) {
+          throw new ValidationException(String.format("Affinity rule for operators %s & %s conflicts with anti affinity rule", entry.getKey().first, entry.getKey().second));
+        }
+      }
+    }
+
+    for (StreamMeta stream : getAllStreams()) {
+      String source = stream.source.getOperatorMeta().getName();
+      for (InputPortMeta sink : stream.sinks) {
+        String sinkOperator = sink.getOperatorWrapper().getName();
+        OperatorPair pair = new OperatorPair(source, sinkOperator);
+        if (stream.locality != null) {
+          if (antiAffinities.containsKey(pair)) {
+            AffinityRule antiRule = antiAffinities.get(pair);
+            if (!isValidRules(antiRule, stream.locality)) {
+              throw new ValidationException(String.format("Locality for operators: %s & %s conflict with anti-affinity rules", source, sinkOperator));
+            }
+          }
+        }
+        if (affinities.containsKey(pair)) {
+          // Choose the lower bound on locality
+          AffinityRule rule = affinities.get(pair);
+          if (rule.getLocality() == Locality.THREAD_LOCAL) {
+            stream.setLocality(rule.getLocality());
+            threadLocalAffinities.remove(rule);
+            affinityRules.remove(rule);
+          }
+          if (stream.locality != null && rule.getLocality().ordinal() > stream.getLocality().ordinal()) {
+          // Remove the affinity rule from attributes, as it is redundant
+            affinityRules.remove(rule);
+          }
+        }
+      }
+    }
+
+    // Validate that all Thread local affinities were for stream connected operators
+    if (!threadLocalAffinities.isEmpty()) {
+      OperatorPair pair = threadLocalAffinities.keySet().iterator().next();
+      throw new ValidationException(String.format("Affinity rule specified THREAD_LOCAL affinity for operators %s & %s which are not connected by stream", pair.first, pair.second));
+    }
+    // Check operators with anti-affinity do not have same host attribute set
+    for (Entry<OperatorPair, AffinityRule> entry : antiAffinities.entrySet()) {
+      OperatorPair pair = entry.getKey();
+      OperatorMeta operator1 = getOperatorMeta(pair.first);
+      OperatorMeta operator2 = getOperatorMeta(pair.second);
+      if (operator1.getAttributes().get(OperatorContext.LOCALITY_HOST) != null && operator2.getAttributes().get(OperatorContext.LOCALITY_HOST) != null) {
+        if (operator1.getAttributes().get(OperatorContext.LOCALITY_HOST).equals(operator2.getAttributes().get(OperatorContext.LOCALITY_HOST))) {
+          throw new ValidationException(String.format("Host Locality for operators: %s & %s conflict with anti-affinity rules", pair.first, pair.second));
+        }
+      }
+    }
+  }
+
+  public void convertRegexToList(List<String> operatorNames, AffinityRule rule, Collection<AffinityRule> removeRules)
+  {
+    List<String> operators =  new LinkedList<String>();
+    Pattern p = Pattern.compile(rule.getOperatorRegex());
+    for(String name : operatorNames) {
+      if (p.matcher(name).matches()) {
+        operators.add(name);
+      }
+    }
+    rule.setOperatorRegex(null);
+    if (operators.size() <= 1) {
+      LOG.warn("Regex should match at least 2 operators to add affinity rule. Ignoring rule");
+      removeRules.add(rule);
+    } else {
+      rule.setOperatorsList(operators);
+    }
+  }
+
+  private boolean isValidRules(AffinityRule antiRule, Locality locality)
+  {
+    // If anti-affinity constraint is smaller than affinity constraint, it is valid to have both rules
+    // For example, if anti-affinity between 2 operators is container and affinity rule between the same 2 operators is Node
+    // If means both rules can be satisfied by having 2 node local containers for both operators.
+    // So these 2 are not conflicting constraints, hence valid
+    return (antiRule.getLocality().ordinal() <  locality.ordinal());
+  }
+
+  private void addToMap(HashMap<OperatorPair, AffinityRule> affinitiesMap, AffinityRule rule)
+  {
+    OperatorPair operators = rule.getOperators();
+    // Check that operator names are part of the dag
+    OperatorMeta operator1 = getOperatorMeta(operators.first);
+    OperatorMeta operator2 = getOperatorMeta(operators.second);
+    if (operator1 == null || operator2 == null) {
+      if (operator1 == null && operator2 == null) {
+        throw new ValidationException(String.format("Operators %s & %s specified in affinity rule are not part of the dag", operators.first, operators.second));
+      }
+      throw new ValidationException(String.format("Operator %s specified in affinity rule is not part of the dag", operator1 == null ? operators.first : operators.second));
+    }
+    affinitiesMap.put(operators, rule);
   }
 
   private void checkAttributeValueSerializable(AttributeMap attributes, String context)

--- a/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlanConfiguration.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlanConfiguration.java
@@ -32,7 +32,6 @@ import java.lang.reflect.Type;
 import java.util.*;
 import java.util.Map.Entry;
 
-
 import javax.validation.ValidationException;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -60,6 +59,7 @@ import com.datatorrent.api.Attribute.AttributeMap.AttributeInitializer;
 import com.datatorrent.api.Context.DAGContext;
 import com.datatorrent.api.Context.OperatorContext;
 import com.datatorrent.api.Context.PortContext;
+import com.datatorrent.api.StringCodec.JsonStringCodec;
 import com.datatorrent.api.annotation.ApplicationAnnotation;
 
 import com.datatorrent.stram.StramUtils;
@@ -2435,7 +2435,7 @@ public class LogicalPlanConfiguration {
           else {
             if (processedAttributes.add(attribute)) {
               String val = e.getValue();
-              if (val.trim().charAt(0) == '{') {
+              if (val.trim().charAt(0) == '{' && !(attribute.codec instanceof JsonStringCodec)) {
                 // complex attribute in json
                 attributeMap.put(attribute, jsonCodec.fromString(val));
               } else {

--- a/engine/src/main/java/com/datatorrent/stram/plan/physical/PTContainer.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/physical/PTContainer.java
@@ -20,7 +20,9 @@ package com.datatorrent.stram.plan.physical;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.esotericsoftware.kryo.KryoException;
 import com.esotericsoftware.kryo.io.Input;
@@ -46,6 +48,8 @@ import com.datatorrent.stram.Journal.Recoverable;
 public class PTContainer implements java.io.Serializable
 {
   private static final long serialVersionUID = 201312112033L;
+  private final Set<PTContainer> strictAntiPrefs = new HashSet<>();
+  private final Set<PTContainer> preferredAntiPrefs = new HashSet<>();
 
   public final static Recoverable SET_CONTAINER_STATE = new SetContainerState();
 
@@ -295,5 +299,15 @@ public class PTContainer implements java.io.Serializable
         append("state", this.getState()).
         append("operators", this.operators).
         toString();
+  }
+
+  public Set<PTContainer> getPreferredAntiPrefs()
+  {
+    return preferredAntiPrefs;
+  }
+
+  public Set<PTContainer> getStrictAntiPrefs()
+  {
+    return strictAntiPrefs;
   }
 }

--- a/engine/src/test/java/com/datatorrent/stram/AffinityRulesTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/AffinityRulesTest.java
@@ -1,0 +1,175 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.datatorrent.stram;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.apache.hadoop.yarn.api.records.NodeReport;
+import org.apache.hadoop.yarn.api.records.NodeState;
+import org.apache.hadoop.yarn.server.utils.BuilderUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import com.datatorrent.api.AffinityRule;
+import com.datatorrent.api.AffinityRule.OperatorPair;
+import com.datatorrent.api.AffinityRule.Type;
+import com.datatorrent.api.AffinityRulesSet;
+import com.datatorrent.api.Context.DAGContext;
+import com.datatorrent.api.Context.OperatorContext;
+import com.datatorrent.api.DAG.Locality;
+import com.datatorrent.common.partitioner.StatelessPartitioner;
+import com.datatorrent.stram.StreamingContainerAgent.ContainerStartRequest;
+import com.datatorrent.stram.engine.GenericTestOperator;
+import com.datatorrent.stram.engine.TestGeneratorInputOperator;
+import com.datatorrent.stram.plan.logical.LogicalPlan;
+import com.datatorrent.stram.plan.physical.PTContainer;
+import com.datatorrent.stram.plan.physical.PTOperator;
+import com.datatorrent.stram.support.StramTestSupport.MemoryStorageAgent;
+
+public class AffinityRulesTest
+{
+  private static final Logger LOG = LoggerFactory.getLogger(AffinityRulesTest.class);
+
+  @Test
+  public void testOperatorPartitionsAntiAffinity()
+  {
+    LogicalPlan dag = new LogicalPlan();
+    TestGeneratorInputOperator o1 = dag.addOperator("O1", new TestGeneratorInputOperator());
+    GenericTestOperator o2 = dag.addOperator("O2", new GenericTestOperator());
+    GenericTestOperator o3 = dag.addOperator("O3", new GenericTestOperator());
+    dag.addStream("stream1", o1.outport, o2.inport1);
+    dag.addStream("stream2", o2.outport1, o3.inport1);
+
+    dag.setAttribute(o2, OperatorContext.PARTITIONER, new StatelessPartitioner<GenericTestOperator>(5));
+
+    AffinityRulesSet ruleSet = new AffinityRulesSet();
+    // Valid case:
+    List<AffinityRule> rules = new ArrayList<>();
+    ruleSet.setAffinityRules(rules);
+    AffinityRule rule1 = new AffinityRule(Type.ANTI_AFFINITY, new OperatorPair("O2", "O2"), Locality.NODE_LOCAL, false);
+    rules.add(rule1);
+    dag.setAttribute(DAGContext.AFFINITY_RULES_SET, ruleSet);
+    dag.validate();
+    dag.getAttributes().put(com.datatorrent.api.Context.DAGContext.APPLICATION_PATH, new File("target", HostLocalTest.class.getName()).getAbsolutePath());
+    dag.setAttribute(OperatorContext.STORAGE_AGENT, new MemoryStorageAgent());
+
+    StreamingContainerManager scm = new StreamingContainerManager(dag);
+
+    // Check Physical Plan assigns anti-affinity preferences correctly
+
+    for (ContainerStartRequest csr : scm.containerStartRequests) {
+      PTContainer container = csr.container;
+      // Check that for containers for O2 partitions, anti-affinity Preference
+      // are set properly
+
+      if (container.getOperators().get(0).getName().equals("O2")) {
+        Assert.assertEquals("Anti-affinity containers set should have 4 containers for other partitions ", 4, container.getStrictAntiPrefs().size());
+        for (PTContainer c : container.getStrictAntiPrefs()) {
+          for (PTOperator operator : c.getOperators()) {
+            Assert.assertEquals("Partion for O2 should be Anti Prefs", "O2", operator.getName());
+          }
+        }
+      }
+    }
+
+    // Check resource handler assigns different hosts for each partition
+
+    ResourceRequestHandler rr = new ResourceRequestHandler();
+    int containerMem = 1000;
+    Map<String, NodeReport> nodeReports = Maps.newHashMap();
+    for (int i = 0; i < 10; i++) {
+      String hostName = "host" + i;
+      NodeReport nr = BuilderUtils.newNodeReport(BuilderUtils.newNodeId(hostName, 0), NodeState.RUNNING, "httpAddress", "rackName", BuilderUtils.newResource(0, 0), BuilderUtils.newResource(containerMem * 2, 2), 0, null, 0);
+      nodeReports.put(nr.getNodeId().getHost(), nr);
+    }
+
+    // set resources
+    rr.updateNodeReports(Lists.newArrayList(nodeReports.values()));
+
+    Set<String> partitionHostNames = new HashSet<>();
+    for (ContainerStartRequest csr : scm.containerStartRequests) {
+      String host = rr.getHost(csr, true);
+      csr.container.host = host;
+      if (csr.container.getOperators().get(0).getName().equals("O2")) {
+        LOG.info("Partition {} for operator O2 has host = {} ", csr.container.getId(), host);
+        Assert.assertTrue("Each Partition should have a different host", !partitionHostNames.contains(host));
+      }
+    }
+  }
+
+  @Test
+  public void testAntiAffinityInOperators()
+  {
+    LogicalPlan dag = new LogicalPlan();
+    dag.getAttributes().put(com.datatorrent.api.Context.DAGContext.APPLICATION_PATH, new File("target", HostLocalTest.class.getName()).getAbsolutePath());
+    dag.setAttribute(OperatorContext.STORAGE_AGENT, new MemoryStorageAgent());
+
+    GenericTestOperator o1 = dag.addOperator("O1", GenericTestOperator.class);
+    dag.setAttribute(o1, OperatorContext.MEMORY_MB, 256);
+
+    GenericTestOperator o2 = dag.addOperator("O2", GenericTestOperator.class);
+    dag.setAttribute(o2, OperatorContext.MEMORY_MB, 256);
+
+    dag.getMeta(o1).getAttributes().put(OperatorContext.LOCALITY_HOST, "host1");
+    AffinityRulesSet ruleSet = new AffinityRulesSet();
+
+    List<AffinityRule> rules = new ArrayList<>();
+    ruleSet.setAffinityRules(rules);
+    AffinityRule rule1 = new AffinityRule(Type.ANTI_AFFINITY, new OperatorPair("O1", "O2"), Locality.NODE_LOCAL, false);
+    rules.add(rule1);
+    dag.setAttribute(DAGContext.AFFINITY_RULES_SET, ruleSet);
+
+    dag.addStream("o1_outport1", o1.outport1, o2.inport1);// .setLocality(Locality.NODE_LOCAL);
+
+    StreamingContainerManager scm = new StreamingContainerManager(dag);
+
+    ResourceRequestHandler rr = new ResourceRequestHandler();
+
+    int containerMem = 1000;
+    Map<String, NodeReport> nodeReports = Maps.newHashMap();
+    NodeReport nr = BuilderUtils.newNodeReport(BuilderUtils.newNodeId("host1", 0), NodeState.RUNNING, "httpAddress", "rackName", BuilderUtils.newResource(0, 0), BuilderUtils.newResource(containerMem * 2, 2), 0, null, 0);
+    nodeReports.put(nr.getNodeId().getHost(), nr);
+    nr = BuilderUtils.newNodeReport(BuilderUtils.newNodeId("host2", 0), NodeState.RUNNING, "httpAddress", "rackName", BuilderUtils.newResource(0, 0), BuilderUtils.newResource(containerMem * 2, 2), 0, null, 0);
+    nodeReports.put(nr.getNodeId().getHost(), nr);
+
+    // set resources
+    rr.updateNodeReports(Lists.newArrayList(nodeReports.values()));
+
+    for (ContainerStartRequest csr : scm.containerStartRequests) {
+      String host = rr.getHost(csr, true);
+      csr.container.host = host;
+      if (csr.container.getOperators().get(0).getName().equals("O1")) {
+        Assert.assertEquals("Hosts set to host1 for Operator O1", "host1", host);
+      }
+      if (csr.container.getOperators().get(0).getName().equals("O2")) {
+        Assert.assertEquals("Hosts set to host2 for Operator O2", "host2", host);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added list of affinity rules as attribute in DAGContext
Added validation for affinity, anti-affinity and locality rules in dag validate phase
Added handling of Container and Node affinity rules. Rack affinity is not supported at this point
Also added Changes for supporting Node specific request in Cloudera
Added Unit tests for affinity rules and dag validation for the same
