### PR TITLE
APEXCORE-353 

### DIFF
--- a/bufferserver/src/main/java/com/datatorrent/bufferserver/internal/DataList.java
+++ b/bufferserver/src/main/java/com/datatorrent/bufferserver/internal/DataList.java
@@ -287,13 +287,13 @@ public class DataList
         @Override
         public void run()
         {
-          boolean atLeastOneListenerHasDataToSend;
-          do {
-            atLeastOneListenerHasDataToSend = false;
-            for (DataListener dl : all_listeners) {
-              atLeastOneListenerHasDataToSend |= dl.addedData();
-            }
-          } while (atLeastOneListenerHasDataToSend);
+          boolean atLeastOneListenerHasDataToSend = false;
+          for (DataListener dl : all_listeners) {
+            atLeastOneListenerHasDataToSend |= dl.addedData();
+          }
+          if (atLeastOneListenerHasDataToSend) {
+            future = autoFlushExecutor.submit(this);
+          }
         }
       });
     }


### PR DESCRIPTION
Allow autoFlushExecutor to process jobs from other datalists when there is more data to send and physical nodes for the current datalist are not ready to get more data.

@PramodSSImmaneni, @tweise Please review and merge.
