### PR TITLE
Fixing cleanup during shutdown to avoid intermittent errors

### DIFF
--- a/engine/src/test/java/com/datatorrent/stram/PartitioningTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/PartitioningTest.java
@@ -260,7 +260,7 @@ public class PartitioningTest
 
     };
     StramTestSupport.awaitCompletion(c, 10000);
-    Assert.assertTrue("Number partitions " + ow, c.isComplete());
+    Assert.assertTrue("Number partitions match " + ow, c.isComplete());
     return lc.getPlanOperators(ow);
   }
 


### PR DESCRIPTION
Was getting intermittent test failures with partitioning test. In debugging noticed the following cleanup problem. Not seeing the test failures anymore but not sure if this fixed it. Will be on the lookup. @tweise please see
