### PR TITLE
APEXCORE-362 - NPE in StreamingContainerManager. 

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/StreamingContainerManager.java
+++ b/engine/src/main/java/com/datatorrent/stram/StreamingContainerManager.java
@@ -1684,8 +1684,12 @@ public class StreamingContainerManager implements PlanContext
           if (stats.windowId > currentEndWindowStatsWindowId) {
             Map<Integer, EndWindowStats> endWindowStatsMap = endWindowStatsOperatorMap.get(stats.windowId);
             if (endWindowStatsMap == null) {
-              endWindowStatsOperatorMap.putIfAbsent(stats.windowId, new ConcurrentSkipListMap<Integer, EndWindowStats>());
-              endWindowStatsMap = endWindowStatsOperatorMap.get(stats.windowId);
+              endWindowStatsMap = new ConcurrentSkipListMap<Integer, EndWindowStats>();
+              Map<Integer, EndWindowStats> endWindowStatsMapPrevious =
+                  endWindowStatsOperatorMap.putIfAbsent(stats.windowId, endWindowStatsMap);
+              if (endWindowStatsMapPrevious != null) {
+                endWindowStatsMap = endWindowStatsMapPrevious;
+              }
             }
             endWindowStatsMap.put(shb.getNodeId(), endWindowStats);
 


### PR DESCRIPTION
Fixed race condition between the thread that insert into endWindowStatsOperatorMap and the thread that removes entries when  endWindowStatsOperatorMap exceeds 1000 entries.

@davidyan74 Please cherry pick into all affected releases.
