### PR TITLE
APEXCORE-363 - NPE in StreamingContainerManager.

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/StreamingContainerManager.java
+++ b/engine/src/main/java/com/datatorrent/stram/StreamingContainerManager.java
@@ -1558,6 +1558,10 @@ public class StreamingContainerManager implements PlanContext
           entry.getValue().recordingId = null;
         }
         for (ContainerStats.OperatorStats stats : statsList) {
+          if (stats == null) {
+            LOG.warn("Operator {} statistics list contains null element", shb.getNodeId());
+            continue;
+          }
 
           /* report checkpoint-ed WindowId status of the operator */
           if (stats.checkpoint instanceof Checkpoint) {


### PR DESCRIPTION
Skip null in the statistics list in case it was inserted as a result of incorrect CircularBuffer usage in the OperatorContext.

@tweise please cherry pick into all affected releases.
