### PR TITLE
APEXCORE-10 #resolve Changes for supporting anti-affinity in operators

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -70,14 +70,6 @@
           <groupId>commons-beanutils</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>jackson-core-asl</artifactId>
-          <groupId>org.codehaus.jackson</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>jackson-mapper-asl</artifactId>
-          <groupId>org.codehaus.jackson</groupId>
-        </exclusion>
-        <exclusion>
           <artifactId>jackson-jaxrs</artifactId>
           <groupId>org.codehaus.jackson</groupId>
         </exclusion>

--- a/api/src/main/java/com/datatorrent/api/AffinityRule.java
+++ b/api/src/main/java/com/datatorrent/api/AffinityRule.java
@@ -1,0 +1,168 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.datatorrent.api;
+
+import java.io.Serializable;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.datatorrent.api.DAG.Locality;
+
+/**
+ * Affinity rule specifies constraints for physical deployment of operator
+ * containers. There are two types of rules that can be specified: Affinity and
+ * Anti-affinity. Each rule contains list of operators or pair of 2 operators or
+ * a regex that should match at least 2 operators. Based on the type of rule,
+ * affinity or anti-affinity, the operators will be deployed together or away
+ * from each other. The locality indicates the level at which the rule should be
+ * applied. E.g. CONTAINER_LOCAL affinity would indicate operators Should be
+ * allocated within same container NODE_LOCAL anti-affinity indicates that the
+ * operators should not be allocated on the same node. The rule can be either
+ * strict or relaxed.
+ *
+ */
+public class AffinityRule implements Serializable
+{
+  Logger LOG = LoggerFactory.getLogger(AffinityRule.class);
+
+  @Override
+  public String toString()
+  {
+    return "AffinityRule {operatorsList=" + operatorsList + ", operatorRegex=" + operatorRegex + ", locality=" + locality + ", type=" + type + ", relaxLocality=" + relaxLocality + "}";
+  }
+
+  private static final long serialVersionUID = 107131504929875386L;
+
+  /**
+   * Type of affinity rule setting affects how operators are scheduled for
+   * deployment by the platform.
+   */
+  public static enum Type
+  {
+    /**
+     * AFFINITY indicates that operators in the rule should be deployed within
+     * locality specified in the rule
+     */
+    AFFINITY,
+    /**
+     * ANTI_AFFINITY indicates that operators in the rule should NOT deployed
+     * within same locality as specified in rule
+     */
+    ANTI_AFFINITY
+  }
+
+  private List<String> operatorsList;
+  private String operatorRegex;
+  private Locality locality;
+  private Type type;
+  private boolean relaxLocality;
+
+  public AffinityRule()
+  {
+  }
+
+  public AffinityRule(Type type, Locality locality, boolean relaxLocality)
+  {
+    this.type = type;
+    this.locality = locality;
+    this.setRelaxLocality(relaxLocality);
+  }
+
+  public AffinityRule(Type type, Locality locality, boolean relaxLocality, String firstOperator, String... otherOperators)
+  {
+    this(type, locality, relaxLocality);
+    LinkedList<String> operators = new LinkedList<String>();
+    if (firstOperator != null && otherOperators.length >= 1) {
+      operators.add(firstOperator);
+
+      for (String operator : otherOperators) {
+        operators.add(operator);
+      }
+      this.setOperatorsList(operators);
+    } else {
+      LOG.warn("Affinity rule should specify at least two operators to be applied");
+    }
+  }
+
+  public AffinityRule(Type type, List<String> operatorsList, Locality locality, boolean relaxLocality)
+  {
+    this(type, locality, relaxLocality);
+    this.operatorsList = operatorsList;
+  }
+
+  public AffinityRule(Type type, String operatorRegex, Locality locality, boolean relaxLocality)
+  {
+    this(type, locality, relaxLocality);
+    this.operatorRegex = operatorRegex;
+  }
+
+  public Locality getLocality()
+  {
+    return locality;
+  }
+
+  public void setLocality(Locality locality)
+  {
+    this.locality = locality;
+  }
+
+  public Type getType()
+  {
+    return type;
+  }
+
+  public void setType(Type type)
+  {
+    this.type = type;
+  }
+
+  public boolean isRelaxLocality()
+  {
+    return relaxLocality;
+  }
+
+  public void setRelaxLocality(boolean relaxLocality)
+  {
+    this.relaxLocality = relaxLocality;
+  }
+
+  public List<String> getOperatorsList()
+  {
+    return operatorsList;
+  }
+
+  public void setOperatorsList(List<String> operatorsList)
+  {
+    this.operatorsList = operatorsList;
+  }
+
+  public String getOperatorRegex()
+  {
+    return operatorRegex;
+  }
+
+  public void setOperatorRegex(String operatorRegex)
+  {
+    this.operatorRegex = operatorRegex;
+  }
+
+}

--- a/api/src/main/java/com/datatorrent/api/AffinityRulesSet.java
+++ b/api/src/main/java/com/datatorrent/api/AffinityRulesSet.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.datatorrent.api;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+/**
+ * Wrapper class for containing set of Affinity rules specified for application
+ */
+public class AffinityRulesSet implements Serializable
+{
+  private Collection<AffinityRule> affinityRules;
+  
+  private static final long serialVersionUID = -8393974533796177171L;
+
+  public Collection<AffinityRule> getAffinityRules()
+  {
+    return affinityRules;
+  }
+
+  public void setAffinityRules(Collection<AffinityRule> affinityRules)
+  {
+    this.affinityRules = affinityRules;
+  }
+}

--- a/api/src/main/java/com/datatorrent/api/Context.java
+++ b/api/src/main/java/com/datatorrent/api/Context.java
@@ -28,6 +28,7 @@ import com.datatorrent.api.Operator.ProcessingMode;
 import com.datatorrent.api.StringCodec.Class2String;
 import com.datatorrent.api.StringCodec.Collection2String;
 import com.datatorrent.api.StringCodec.Integer2String;
+import com.datatorrent.api.StringCodec.JsonStringCodec;
 import com.datatorrent.api.StringCodec.Map2String;
 import com.datatorrent.api.StringCodec.Object2String;
 import com.datatorrent.api.StringCodec.String2String;
@@ -510,8 +511,10 @@ public interface Context
     Attribute<Long> BLACKLISTED_NODE_REMOVAL_TIME_MILLIS = new Attribute<Long>(new Long(60 * 60 * 1000));
 
     /**
-     * The number of times consecutive container failure
+     * Affinity rules for specifying affinity and anti-affinity between logical operators
      */
+    Attribute<AffinityRulesSet> AFFINITY_RULES_SET = new Attribute<AffinityRulesSet>(new JsonStringCodec<AffinityRulesSet>(AffinityRulesSet.class));
+
     @SuppressWarnings(value = "FieldNameHidesFieldInSuperclass")
     long serialVersionUID = AttributeMap.AttributeInitializer.initialize(DAGContext.class);
   }

--- a/engine/src/main/java/com/datatorrent/stram/BlacklistBasedResourceRequestHandler.java
+++ b/engine/src/main/java/com/datatorrent/stram/BlacklistBasedResourceRequestHandler.java
@@ -1,0 +1,141 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.datatorrent.stram;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.tuple.MutablePair;
+import org.apache.hadoop.yarn.client.api.AMRMClient;
+import org.apache.hadoop.yarn.client.api.AMRMClient.ContainerRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.datatorrent.stram.StreamingContainerAgent.ContainerStartRequest;
+
+/**
+ * Handles creating container requests and issuing node-specific container
+ * requests by blacklisting (specifically for cloudera)
+ * 
+ * Host specific container requests are not allocated on Cloudera as captured in
+ * Jira Yarn-1412 (https://issues.apache.org/jira/browse/YARN-1412) 
+ * To handle such requests, we blacklist all the other nodes before issueing node request.
+ */
+public class BlacklistBasedResourceRequestHandler extends ResourceRequestHandler
+{
+  HashMap<ContainerRequest, ContainerStartRequest> hostSpecificRequests = new HashMap<>();
+  HashMap<ContainerRequest, ContainerStartRequest> otherContainerRequests = new HashMap<>();
+  HashMap<String, List<ContainerRequest>> hostSpecificRequestsMap = new HashMap<>();
+  List<String> blacklistedNodesForHostSpecificRequests = null;
+
+  public void reissueContainerRequests(AMRMClient<ContainerRequest> amRmClient, Map<StreamingContainerAgent.ContainerStartRequest, MutablePair<Integer, ContainerRequest>> requestedResources, int loopCounter, ResourceRequestHandler resourceRequestor, List<ContainerRequest> containerRequests, List<ContainerRequest> removedContainerRequests)
+  {
+    // Issue all host specific requests first
+    if (!hostSpecificRequestsMap.isEmpty() && requestedResources.isEmpty()) {
+      LOG.info("Issue Host specific requests first");
+      // Blacklist all the nodes and issue request for host specific
+      Entry<String, List<ContainerRequest>> set = hostSpecificRequestsMap.entrySet().iterator().next();
+      List<ContainerRequest> requests = set.getValue();
+      List<String> blacklistNodes = resourceRequestor.getNodesExceptHost(requests.get(0).getNodes());
+      amRmClient.updateBlacklist(blacklistNodes, requests.get(0).getNodes());
+      blacklistedNodesForHostSpecificRequests = blacklistNodes;
+      LOG.info("Sending {} request(s) after blacklisting all nodes other than {}", requests.size(), requests.get(0).getNodes());
+
+      for (ContainerRequest cr : requests) {
+        ContainerStartRequest csr = hostSpecificRequests.get(cr);
+        ContainerRequest newCr = new ContainerRequest(cr.getCapability(), null, null, cr.getPriority());
+        MutablePair<Integer, ContainerRequest> pair = new MutablePair<Integer, ContainerRequest>(loopCounter, newCr);
+        requestedResources.put(csr, pair);
+        containerRequests.add(newCr);
+        hostSpecificRequests.remove(cr);
+      }
+      hostSpecificRequestsMap.remove(set.getKey());
+    } else if (!requestedResources.isEmpty()) {
+      // Check if any requests timed out, create new requests in that case
+      recreateContainerRequest(requestedResources, loopCounter, resourceRequestor, removedContainerRequests);
+    } else {
+      if (blacklistedNodesForHostSpecificRequests != null) {
+        // Remove the blacklisted nodes during host specific requests
+        LOG.debug("All requests done.. Removing nodes from blacklist {}", blacklistedNodesForHostSpecificRequests);
+        amRmClient.updateBlacklist(null, blacklistedNodesForHostSpecificRequests);
+        blacklistedNodesForHostSpecificRequests = null;
+      }
+      // Proceed with other requests after host specific requests are done
+      if (!otherContainerRequests.isEmpty()) {
+        for (Entry<ContainerRequest, ContainerStartRequest> entry : otherContainerRequests.entrySet()) {
+          ContainerRequest cr = entry.getKey();
+          ContainerStartRequest csr = entry.getValue();
+          MutablePair<Integer, ContainerRequest> pair = new MutablePair<Integer, ContainerRequest>(loopCounter, cr);
+          requestedResources.put(csr, pair);
+          containerRequests.add(cr);
+        }
+        otherContainerRequests.clear();
+      }
+    }
+  }
+
+  public void recreateContainerRequest(Map<StreamingContainerAgent.ContainerStartRequest, MutablePair<Integer, ContainerRequest>> requestedResources, int loopCounter, ResourceRequestHandler resourceRequestor, List<ContainerRequest> removedContainerRequests)
+  {
+    for (Map.Entry<StreamingContainerAgent.ContainerStartRequest, MutablePair<Integer, ContainerRequest>> entry : requestedResources.entrySet()) {
+      if ((loopCounter - entry.getValue().getKey()) > NUMBER_MISSED_HEARTBEATS) {
+        StreamingContainerAgent.ContainerStartRequest csr = entry.getKey();
+        removedContainerRequests.add(entry.getValue().getRight());
+        ContainerRequest cr = resourceRequestor.createContainerRequest(csr, false);
+        if (cr.getNodes() != null && !cr.getNodes().isEmpty()) {
+          addHostSpecificRequest(csr, cr);
+        } else {
+          otherContainerRequests.put(cr, csr);
+        }
+      }
+    }
+  }
+
+  public void addContainerRequest(Map<StreamingContainerAgent.ContainerStartRequest, MutablePair<Integer, ContainerRequest>> requestedResources, int loopCounter, List<ContainerRequest> containerRequests, StreamingContainerAgent.ContainerStartRequest csr, ContainerRequest cr)
+  {
+    if (cr.getNodes() != null && !cr.getNodes().isEmpty()) {
+      // Put it in a Map to check if multiple requests can be combined
+      addHostSpecificRequest(csr, cr);
+    } else {
+      LOG.info("No node specific request ", cr);
+      otherContainerRequests.put(cr, csr);
+    }
+  }
+
+  public void addHostSpecificRequest(StreamingContainerAgent.ContainerStartRequest csr, ContainerRequest cr)
+  {
+    String hostKey = StringUtils.join(cr.getNodes(), ":");
+    List<ContainerRequest> requests;
+    if (hostSpecificRequestsMap.containsKey(hostKey)) {
+      requests = hostSpecificRequestsMap.get(hostKey);
+    } else {
+      requests = new ArrayList<>();
+    }
+    requests.add(cr);
+    hostSpecificRequestsMap.put(hostKey, requests);
+    LOG.info("Requesting container for node {} request = {}", cr.getNodes(), cr);
+    hostSpecificRequests.put(cr, csr);
+  }
+
+  private static final Logger LOG = LoggerFactory.getLogger(BlacklistBasedResourceRequestHandler.class);
+}

--- a/engine/src/main/java/com/datatorrent/stram/ResourceRequestHandler.java
+++ b/engine/src/main/java/com/datatorrent/stram/ResourceRequestHandler.java
@@ -18,13 +18,18 @@
  */
 package com.datatorrent.stram;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.hadoop.yarn.api.records.NodeReport;
+import org.apache.hadoop.yarn.api.records.NodeState;
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.client.api.AMRMClient;
 import org.apache.hadoop.yarn.client.api.AMRMClient.ContainerRequest;
 import org.apache.hadoop.yarn.util.Records;
 import org.slf4j.Logger;
@@ -48,10 +53,56 @@ public class ResourceRequestHandler
 {
 
   private final static Logger LOG = LoggerFactory.getLogger(ResourceRequestHandler.class);
+  private final static String INVALID_HOST = "INVALID_HOST";
+
+  protected static final int NUMBER_MISSED_HEARTBEATS = 30;
 
   public ResourceRequestHandler()
   {
     super();
+  }
+
+  /**
+   * Issue requests to AM RM Client again if previous container requests expired and were not allocated by Yarn
+   * @param amRmClient
+   * @param requestedResources
+   * @param loopCounter
+   * @param resourceRequestor
+   * @param containerRequests
+   * @param removedContainerRequests
+   */
+  public void reissueContainerRequests(AMRMClient<ContainerRequest> amRmClient, Map<StreamingContainerAgent.ContainerStartRequest, MutablePair<Integer, ContainerRequest>> requestedResources, int loopCounter, ResourceRequestHandler resourceRequestor, List<ContainerRequest> containerRequests, List<ContainerRequest> removedContainerRequests)
+  {
+    if (!requestedResources.isEmpty()) {
+      for (Map.Entry<StreamingContainerAgent.ContainerStartRequest, MutablePair<Integer, ContainerRequest>> entry : requestedResources.entrySet()) {
+        /*
+         * Create container requests again if pending requests were not allocated by Yarn till timeout.
+         */
+        if ((loopCounter - entry.getValue().getKey()) > NUMBER_MISSED_HEARTBEATS) {
+          StreamingContainerAgent.ContainerStartRequest csr = entry.getKey();
+          removedContainerRequests.add(entry.getValue().getRight());
+          ContainerRequest cr = resourceRequestor.createContainerRequest(csr, false);
+          entry.getValue().setLeft(loopCounter);
+          entry.getValue().setRight(cr);
+          containerRequests.add(cr);
+        }
+      }
+    }
+  }
+
+  /**
+   * Add container request to list of issued requests to Yarn along with current loop counter
+   * @param requestedResources
+   * @param loopCounter
+   * @param containerRequests
+   * @param csr
+   * @param cr
+   */
+  public void addContainerRequest(Map<StreamingContainerAgent.ContainerStartRequest, MutablePair<Integer, ContainerRequest>> requestedResources, int loopCounter, List<ContainerRequest> containerRequests, StreamingContainerAgent.ContainerStartRequest csr, ContainerRequest cr)
+  {
+    MutablePair<Integer, ContainerRequest> pair = new MutablePair<Integer, ContainerRequest>(loopCounter, cr);
+    requestedResources.put(csr, pair);
+    containerRequests.add(cr);
   }
 
   /**
@@ -68,7 +119,9 @@ public class ResourceRequestHandler
     Resource capability = Records.newRecord(Resource.class);
     capability.setMemory(csr.container.getRequiredMemoryMB());
     capability.setVirtualCores(csr.container.getRequiredVCores());
-
+    if (host == INVALID_HOST) {
+      return null;
+    }
     if (host != null) {
       nodes = new String[]{host};
       // in order to request a host, we don't have to set the rack if the locality is false
@@ -84,6 +137,7 @@ public class ResourceRequestHandler
   private final Map<String, NodeReport> nodeReportMap = Maps.newHashMap();
   private final Map<Set<PTOperator>, String> nodeLocalMapping = Maps.newHashMap();
   private final Map<String, String> nodeToRack = Maps.newHashMap();
+  private final Map<PTContainer, String> antiAffinityMapping = Maps.newHashMap();
 
   public void clearNodeMapping()
   {
@@ -108,6 +162,24 @@ public class ResourceRequestHandler
     }
   }
 
+  public List<String> getNodesExceptHost(List<String> hostNames)
+  {
+    List<String> nodesList = new ArrayList<String>();
+    Set<String> hostNameSet = Sets.newHashSet();
+    hostNameSet.addAll(hostNames);
+    for (String host : nodeReportMap.keySet()) {
+      // Split node name and port
+      String[] parts = host.split(":");
+      if (parts.length > 0) {
+        if (hostNameSet.contains(parts[0]) || hostNameSet.contains(host)) {
+          continue;
+        }
+        nodesList.add(parts[0]);
+      }
+    }
+    return nodesList;
+  }
+
   public String getHost(ContainerStartRequest csr, boolean first)
   {
     String host = null;
@@ -117,6 +189,7 @@ public class ResourceRequestHandler
         HostOperatorSet grpObj = oper.getNodeLocalOperators();
         host = nodeLocalMapping.get(grpObj.getOperatorSet());
         if (host != null) {
+          antiAffinityMapping.put(c, host);
           return host;
         }
         if (grpObj.getHost() != null) {
@@ -145,6 +218,7 @@ public class ResourceRequestHandler
           int vCoresAvailable = report.getCapability().getVirtualCores() - report.getUsed().getVirtualCores();
           if (memAvailable >= aggrMemory && vCoresAvailable >= vCores) {
             nodeLocalMapping.put(nodeLocalSet, host);
+            antiAffinityMapping.put(c, host);
             return host;
           }
         }
@@ -153,11 +227,21 @@ public class ResourceRequestHandler
 
     // the host requested didn't have the resources so looking for other hosts
     host = null;
+    List<String> antiHosts = new ArrayList<>();
+    List<String> antiPreferredHosts = new ArrayList<>();
+    if (!c.getStrictAntiPrefs().isEmpty()) {
+      // Check if containers are allocated already for the anti-affinity containers
+      populateAntiHostList(c, antiHosts);
+    }
+    if (!c.getPreferredAntiPrefs().isEmpty()) {
+      populateAntiHostList(c, antiPreferredHosts);
+    }
+    LOG.info("Strict anti-affinity = {} for container with operators {}", antiHosts, StringUtils.join(c.getOperators(), ","));
     for (PTOperator oper : c.getOperators()) {
       HostOperatorSet grpObj = oper.getNodeLocalOperators();
       Set<PTOperator> nodeLocalSet = grpObj.getOperatorSet();
-      if (nodeLocalSet.size() > 1) {
-        LOG.debug("Finding new host for {}", nodeLocalSet);
+      if (nodeLocalSet.size() > 1 ||  !c.getStrictAntiPrefs().isEmpty() || !c.getPreferredAntiPrefs().isEmpty()) {
+        LOG.info("Finding new host for {}", nodeLocalSet);
         int aggrMemory = c.getRequiredMemoryMB();
         int vCores = c.getRequiredVCores();
         Set<PTContainer> containers = Sets.newHashSet();
@@ -170,19 +254,92 @@ public class ResourceRequestHandler
             containers.add(nodeLocalOper.getContainer());
           }
         }
-        for (Map.Entry<String, NodeReport> nodeEntry : nodeReportMap.entrySet()) {
-          int memAvailable = nodeEntry.getValue().getCapability().getMemory() - nodeEntry.getValue().getUsed().getMemory();
-          int vCoresAvailable = nodeEntry.getValue().getCapability().getVirtualCores() - nodeEntry.getValue().getUsed().getVirtualCores();
-          if (memAvailable >= aggrMemory && vCoresAvailable >= vCores) {
-            host = nodeEntry.getKey();
-            grpObj.setHost(host);
-            nodeLocalMapping.put(nodeLocalSet, host);
-            return host;
-          }
+        host = assignHost(host, antiHosts, antiPreferredHosts, grpObj, nodeLocalSet, aggrMemory, vCores);
+
+        if (host == null && !antiPreferredHosts.isEmpty() && !antiHosts.isEmpty()) {
+          // Drop the preferred constraint and try allocation
+          antiPreferredHosts.clear();
+          host = assignHost(host, antiHosts, antiPreferredHosts, grpObj, nodeLocalSet, aggrMemory, vCores);
+        }
+        if (host != null) {
+          antiAffinityMapping.put(c, host);
+        } else {
+          host = INVALID_HOST;
         }
       }
     }
+    LOG.info("Found host {}", host);
     return host;
+  }
+
+  /**
+   * Populate list of nodes where container cannot be allocated due to anti-affinity constraints
+   * @param container
+   * @param List of nodes where container cannot be allocated
+   */
+  public void populateAntiHostList(PTContainer c, List<String> antiHosts)
+  {
+    for (PTContainer container : c.getStrictAntiPrefs()) {
+      if (antiAffinityMapping.containsKey(container)) {
+        antiHosts.add(antiAffinityMapping.get(container));
+      } else {
+        // Check if there is an anti-affinity with host locality
+        String antiHost = getHostForContainer(container);
+        if (antiHost != null) {
+          antiHosts.add(antiHost);
+        }
+      }
+    }
+  }
+
+  /**
+   * Get host name where container would be allocated give node local constraints
+   * @param container
+   * @return
+   */
+  public String getHostForContainer(PTContainer container)
+  {
+    for (PTOperator oper : container.getOperators()) {
+      HostOperatorSet grpObj = oper.getNodeLocalOperators();
+      String host = nodeLocalMapping.get(grpObj.getOperatorSet());
+      if (host != null) {
+        return host;
+      }
+      if (grpObj.getHost() != null) {
+        host = grpObj.getHost();
+        return host;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Assign host to container given affinity and anti-affinity constraints and resource availibility on node
+   * @param host
+   * @param antiHosts
+   * @param antiPreferredHosts
+   * @param grpObj
+   * @param nodeLocalSet
+   * @param aggrMemory
+   * @param vCores
+   * @return
+   */
+  public String assignHost(String host, List<String> antiHosts, List<String> antiPreferredHosts, HostOperatorSet grpObj, Set<PTOperator> nodeLocalSet, int aggrMemory, int vCores)
+  {
+    for (Map.Entry<String, NodeReport> nodeEntry : nodeReportMap.entrySet()) {
+      if (nodeEntry.getValue().getNodeState() == NodeState.RUNNING) {
+        int memAvailable = nodeEntry.getValue().getCapability().getMemory() - nodeEntry.getValue().getUsed().getMemory();
+        int vCoresAvailable = nodeEntry.getValue().getCapability().getVirtualCores() - nodeEntry.getValue().getUsed().getVirtualCores();
+        if (memAvailable >= aggrMemory && vCoresAvailable >= vCores && !antiHosts.contains(nodeEntry.getKey()) && !antiPreferredHosts.contains(nodeEntry.getKey())) {
+          host = nodeEntry.getKey();
+          grpObj.setHost(host);
+          nodeLocalMapping.put(nodeLocalSet, host);
+
+          return host;
+        }
+      }
+    }
+    return null;
   }
 
 }

--- a/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlanConfiguration.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlanConfiguration.java
@@ -32,7 +32,6 @@ import java.lang.reflect.Type;
 import java.util.*;
 import java.util.Map.Entry;
 
-
 import javax.validation.ValidationException;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -60,6 +59,7 @@ import com.datatorrent.api.Attribute.AttributeMap.AttributeInitializer;
 import com.datatorrent.api.Context.DAGContext;
 import com.datatorrent.api.Context.OperatorContext;
 import com.datatorrent.api.Context.PortContext;
+import com.datatorrent.api.StringCodec.JsonStringCodec;
 import com.datatorrent.api.annotation.ApplicationAnnotation;
 
 import com.datatorrent.stram.StramUtils;
@@ -2435,7 +2435,7 @@ public class LogicalPlanConfiguration {
           else {
             if (processedAttributes.add(attribute)) {
               String val = e.getValue();
-              if (val.trim().charAt(0) == '{') {
+              if (val.trim().charAt(0) == '{' && !(attribute.codec instanceof JsonStringCodec)) {
                 // complex attribute in json
                 attributeMap.put(attribute, jsonCodec.fromString(val));
               } else {

--- a/engine/src/main/java/com/datatorrent/stram/plan/physical/PTContainer.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/physical/PTContainer.java
@@ -20,7 +20,9 @@ package com.datatorrent.stram.plan.physical;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.esotericsoftware.kryo.KryoException;
 import com.esotericsoftware.kryo.io.Input;
@@ -46,6 +48,8 @@ import com.datatorrent.stram.Journal.Recoverable;
 public class PTContainer implements java.io.Serializable
 {
   private static final long serialVersionUID = 201312112033L;
+  private final Set<PTContainer> strictAntiPrefs = new HashSet<>();
+  private final Set<PTContainer> preferredAntiPrefs = new HashSet<>();
 
   public final static Recoverable SET_CONTAINER_STATE = new SetContainerState();
 
@@ -295,5 +299,15 @@ public class PTContainer implements java.io.Serializable
         append("state", this.getState()).
         append("operators", this.operators).
         toString();
+  }
+
+  public Set<PTContainer> getPreferredAntiPrefs()
+  {
+    return preferredAntiPrefs;
+  }
+
+  public Set<PTContainer> getStrictAntiPrefs()
+  {
+    return strictAntiPrefs;
   }
 }

--- a/engine/src/test/java/com/datatorrent/stram/AffinityRulesTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/AffinityRulesTest.java
@@ -1,0 +1,180 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.datatorrent.stram;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.apache.hadoop.yarn.api.records.NodeReport;
+import org.apache.hadoop.yarn.api.records.NodeState;
+import org.apache.hadoop.yarn.server.utils.BuilderUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import com.datatorrent.api.AffinityRule;
+import com.datatorrent.api.AffinityRule.Type;
+import com.datatorrent.api.AffinityRulesSet;
+import com.datatorrent.api.Context.DAGContext;
+import com.datatorrent.api.Context.OperatorContext;
+import com.datatorrent.api.DAG.Locality;
+import com.datatorrent.common.partitioner.StatelessPartitioner;
+import com.datatorrent.stram.StreamingContainerAgent.ContainerStartRequest;
+import com.datatorrent.stram.engine.GenericTestOperator;
+import com.datatorrent.stram.engine.TestGeneratorInputOperator;
+import com.datatorrent.stram.plan.logical.LogicalPlan;
+import com.datatorrent.stram.plan.physical.PTContainer;
+import com.datatorrent.stram.plan.physical.PTOperator;
+import com.datatorrent.stram.support.StramTestSupport.MemoryStorageAgent;
+import com.datatorrent.stram.support.StramTestSupport.TestMeta;
+
+public class AffinityRulesTest
+{
+  private static final Logger LOG = LoggerFactory.getLogger(AffinityRulesTest.class);
+
+  @Rule
+  public TestMeta testMeta = new TestMeta();
+  
+  @Test
+  public void testOperatorPartitionsAntiAffinity()
+  {
+    LogicalPlan dag = new LogicalPlan();
+    TestGeneratorInputOperator o1 = dag.addOperator("O1", new TestGeneratorInputOperator());
+    GenericTestOperator o2 = dag.addOperator("O2", new GenericTestOperator());
+    GenericTestOperator o3 = dag.addOperator("O3", new GenericTestOperator());
+    dag.addStream("stream1", o1.outport, o2.inport1);
+    dag.addStream("stream2", o2.outport1, o3.inport1);
+
+    dag.setAttribute(o2, OperatorContext.PARTITIONER, new StatelessPartitioner<GenericTestOperator>(5));
+
+    AffinityRulesSet ruleSet = new AffinityRulesSet();
+    // Valid case:
+    List<AffinityRule> rules = new ArrayList<>();
+    ruleSet.setAffinityRules(rules);
+    AffinityRule rule1 = new AffinityRule(Type.ANTI_AFFINITY, Locality.NODE_LOCAL, false, "O2", "O2");
+    rules.add(rule1);
+    dag.setAttribute(DAGContext.AFFINITY_RULES_SET, ruleSet);
+    dag.validate();
+    dag.getAttributes().put(com.datatorrent.api.Context.DAGContext.APPLICATION_PATH, testMeta.getAbsolutePath());
+    dag.setAttribute(OperatorContext.STORAGE_AGENT, new MemoryStorageAgent());
+
+    StreamingContainerManager scm = new StreamingContainerManager(dag);
+
+    // Check Physical Plan assigns anti-affinity preferences correctly
+
+    for (ContainerStartRequest csr : scm.containerStartRequests) {
+      PTContainer container = csr.container;
+      // Check that for containers for O2 partitions, anti-affinity Preference
+      // are set properly
+
+      if (container.getOperators().get(0).getName().equals("O2")) {
+        Assert.assertEquals("Anti-affinity containers set should have 4 containers for other partitions ", 4, container.getStrictAntiPrefs().size());
+        for (PTContainer c : container.getStrictAntiPrefs()) {
+          for (PTOperator operator : c.getOperators()) {
+            Assert.assertEquals("Partion for O2 should be Anti Prefs", "O2", operator.getName());
+          }
+        }
+      }
+    }
+
+    // Check resource handler assigns different hosts for each partition
+
+    ResourceRequestHandler rr = new ResourceRequestHandler();
+    int containerMem = 1000;
+    Map<String, NodeReport> nodeReports = Maps.newHashMap();
+    for (int i = 0; i < 10; i++) {
+      String hostName = "host" + i;
+      NodeReport nr = BuilderUtils.newNodeReport(BuilderUtils.newNodeId(hostName, 0), NodeState.RUNNING, "httpAddress", "rackName", BuilderUtils.newResource(0, 0), BuilderUtils.newResource(containerMem * 2, 2), 0, null, 0);
+      nodeReports.put(nr.getNodeId().getHost(), nr);
+    }
+
+    // set resources
+    rr.updateNodeReports(Lists.newArrayList(nodeReports.values()));
+
+    Set<String> partitionHostNames = new HashSet<>();
+    for (ContainerStartRequest csr : scm.containerStartRequests) {
+      String host = rr.getHost(csr, true);
+      csr.container.host = host;
+      if (csr.container.getOperators().get(0).getName().equals("O2")) {
+        Assert.assertNotNull("Host name should not be null", host);
+        LOG.info("Partition {} for operator O2 has host = {} ", csr.container.getId(), host);
+        Assert.assertTrue("Each Partition should have a different host", !partitionHostNames.contains(host));
+        partitionHostNames.add(host);
+      }
+    }
+  }
+
+  @Test
+  public void testAntiAffinityInOperators()
+  {
+    LogicalPlan dag = new LogicalPlan();
+    dag.getAttributes().put(com.datatorrent.api.Context.DAGContext.APPLICATION_PATH, testMeta.getAbsolutePath());
+    dag.setAttribute(OperatorContext.STORAGE_AGENT, new MemoryStorageAgent());
+
+    GenericTestOperator o1 = dag.addOperator("O1", GenericTestOperator.class);
+    dag.setAttribute(o1, OperatorContext.MEMORY_MB, 256);
+
+    GenericTestOperator o2 = dag.addOperator("O2", GenericTestOperator.class);
+    dag.setAttribute(o2, OperatorContext.MEMORY_MB, 256);
+
+    dag.getMeta(o1).getAttributes().put(OperatorContext.LOCALITY_HOST, "host1");
+    AffinityRulesSet ruleSet = new AffinityRulesSet();
+
+    List<AffinityRule> rules = new ArrayList<>();
+    ruleSet.setAffinityRules(rules);
+    AffinityRule rule1 = new AffinityRule(Type.ANTI_AFFINITY, Locality.NODE_LOCAL, false, "O1", "O2");
+    rules.add(rule1);
+    dag.setAttribute(DAGContext.AFFINITY_RULES_SET, ruleSet);
+
+    dag.addStream("o1_outport1", o1.outport1, o2.inport1);// .setLocality(Locality.NODE_LOCAL);
+
+    StreamingContainerManager scm = new StreamingContainerManager(dag);
+
+    ResourceRequestHandler rr = new ResourceRequestHandler();
+
+    int containerMem = 1000;
+    Map<String, NodeReport> nodeReports = Maps.newHashMap();
+    NodeReport nr = BuilderUtils.newNodeReport(BuilderUtils.newNodeId("host1", 0), NodeState.RUNNING, "httpAddress", "rackName", BuilderUtils.newResource(0, 0), BuilderUtils.newResource(containerMem * 2, 2), 0, null, 0);
+    nodeReports.put(nr.getNodeId().getHost(), nr);
+    nr = BuilderUtils.newNodeReport(BuilderUtils.newNodeId("host2", 0), NodeState.RUNNING, "httpAddress", "rackName", BuilderUtils.newResource(0, 0), BuilderUtils.newResource(containerMem * 2, 2), 0, null, 0);
+    nodeReports.put(nr.getNodeId().getHost(), nr);
+
+    // set resources
+    rr.updateNodeReports(Lists.newArrayList(nodeReports.values()));
+
+    for (ContainerStartRequest csr : scm.containerStartRequests) {
+      String host = rr.getHost(csr, true);
+      csr.container.host = host;
+      if (csr.container.getOperators().get(0).getName().equals("O1")) {
+        Assert.assertEquals("Hosts set to host1 for Operator O1", "host1", host);
+      }
+      if (csr.container.getOperators().get(0).getName().equals("O2")) {
+        Assert.assertEquals("Hosts set to host2 for Operator O2", "host2", host);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added list of affinity rules as attribute in DAGContext
Added validation for affinity, anti-affinity and locality rules in dag validate phase
Added handling of Container and Node affinity rules. Rack affinity is not supported at this point
Also added Changes for supporting Node specific request in Cloudera
Added Unit tests for affinity rules and dag validation for the same
Added Json String codec for setting affinity rules through properties.xml
Added Set Affinity and anti -affinity APIs to dag
