### PR TITLE
APEXCORE-130 - Throwing A Runtime Exception In Setup Causes The Operator To Block.

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -149,7 +149,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <configuration>
-          <maxAllowedViolations>3184</maxAllowedViolations>
+          <maxAllowedViolations>3179</maxAllowedViolations>
           <logViolationsToConsole>${checkstyle.console}</logViolationsToConsole>
         </configuration>
       </plugin>

--- a/engine/src/main/java/com/datatorrent/stram/engine/Node.java
+++ b/engine/src/main/java/com/datatorrent/stram/engine/Node.java
@@ -631,7 +631,6 @@ public abstract class Node<OPERATOR extends Operator> implements Component<Opera
       CHECKPOINT_WINDOW_COUNT = 1;
     }
 
-    context.setThread(Thread.currentThread());
     activateSinks();
     if (operator instanceof Operator.ActivationListener) {
       ((Operator.ActivationListener<OperatorContext>) operator).activate(context);

--- a/engine/src/main/java/com/datatorrent/stram/engine/StreamingContainer.java
+++ b/engine/src/main/java/com/datatorrent/stram/engine/StreamingContainer.java
@@ -1351,7 +1351,13 @@ public class StreamingContainer extends YarnContainerMain
       }
 
       final Node<?> node = nodes.get(ndi.id);
-      new Thread(Integer.toString(ndi.id).concat("/").concat(ndi.name).concat(":").concat(node.getOperator().getClass().getSimpleName()))
+      final String name = new StringBuilder(Integer.toString(ndi.id))
+          .append('/')
+          .append(ndi.name)
+          .append(':')
+          .append(node.getOperator().getClass().getSimpleName())
+          .toString();
+      final Thread thread = new Thread(name)
       {
         @Override
         public void run()
@@ -1437,8 +1443,9 @@ public class StreamingContainer extends YarnContainerMain
             }
           }
         }
-
-      }.start();
+      };
+      node.context.setThread(thread);
+      thread.start();
     }
 
     /**


### PR DESCRIPTION
Moved thread assignment from Node.active() to StreamingContainer.

@tweise, @ilooner Please review
