### PR TITLE
apexcore-407 adaptive spin millis for input operators

### DIFF
--- a/api/src/main/java/com/datatorrent/api/Context.java
+++ b/api/src/main/java/com/datatorrent/api/Context.java
@@ -194,7 +194,8 @@ public interface Context
      */
     Attribute<Long> ACTIVATION_WINDOW_ID = new Attribute<Long>(Stateless.WINDOW_ID);
     /**
-     * Poll period in milliseconds when there are no tuples available on any of the input ports of the operator.
+     * It is a maximum poll period in milliseconds when there are no tuples available on any of the input ports of the
+     * operator. Platform uses the heuristic to change poll period from 0 to SPIN_MILLIS seconds.
      * Default value is 10 milliseconds.
      */
     Attribute<Integer> SPIN_MILLIS = new Attribute<Integer>(10);

--- a/engine/src/main/java/com/datatorrent/stram/engine/InputNode.java
+++ b/engine/src/main/java/com/datatorrent/stram/engine/InputNode.java
@@ -66,7 +66,8 @@ public class InputNode extends Node<InputOperator>
   @SuppressWarnings(value = {"SleepWhileInLoop", "BroadCatchBlock", "TooBroadCatch"})
   public final void run()
   {
-    long spinMillis = context.getValue(OperatorContext.SPIN_MILLIS);
+    long maxSpinMillis = context.getValue(OperatorContext.SPIN_MILLIS);
+    long spinMillis = 0;
     final boolean handleIdleTime = operator instanceof IdleTimeHandler;
 
     boolean insideApplicationWindow = applicationWindowCount != 0;
@@ -98,7 +99,10 @@ public class InputNode extends Node<InputOperator>
               }
               else {
                 Thread.sleep(spinMillis);
+                spinMillis = Math.min(spinMillis + 1, maxSpinMillis);
               }
+            } else {
+              spinMillis = 0;
             }
           }
           else {


### PR DESCRIPTION
I tested change with the benchmarking and I can clearly see the improvement in performance. It is similar to what was done before

https://issues.apache.org/jira/browse/APEXCORE-380
https://github.com/apache/incubator-apex-core/pull/271

Performance numbers increased from <710000 tuples/sec to >10,00,000 tuples/sec.

This change was reviewed by @vrozov, closed the old one as Travis build was failing. 
