### PR TITLE
APEXCORE-422 reverted the change that suppresses all the AnnotationLocation violations

### DIFF
--- a/codestyle-config/src/main/resources/apex_checks.xml
+++ b/codestyle-config/src/main/resources/apex_checks.xml
@@ -154,7 +154,7 @@
     <module name="AnnotationLocation">
       <property name="allowSamelineMultipleAnnotations" value="false"/>
       <property name="allowSamelineSingleParameterlessAnnotation" value="false"/>
-      <property name="allowSamelineParameterizedAnnotation" value="true"/>
+      <property name="allowSamelineParameterizedAnnotation" value="false"/>
     </module>
 
     <module name="ImportOrder">

--- a/engine/engine-checkstyle-suppressions.xml
+++ b/engine/engine-checkstyle-suppressions.xml
@@ -28,5 +28,6 @@
   <suppress checks="RegexpMultiline" files=".*Tests?.java"/>
   <suppress checks="RegexpMultiline" files="VersionInfo.java"/>
   <suppress checks="NoFinalizer" files="FSRecoveryHandler.java"/>
-  <suppress checks="AnnotationLocation" files=".*.java"/>
+  <suppress checks="AnnotationLocation" files="PhysicalPlan.java"/>
+  <suppress checks="AnnotationLocation" files="ApexCli.java"/>
 </suppressions>


### PR DESCRIPTION
@davidyan74 @vrozov 

travis is going to fail because the new 1.0.1-incubating version is not yet available. we need to push that version to maven central first.
