### PR TITLE
APEXCORE-439 Fix for operator re-deployment during dynamic partitioning

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/plan/physical/PhysicalPlan.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/physical/PhysicalPlan.java
@@ -1122,11 +1122,20 @@ public class PhysicalPlan implements Serializable
     Set<PTContainer> releaseContainers = Sets.newHashSet();
     assignContainers(newContainers, releaseContainers);
     updatePartitionsInfoForPersistOperator(this.dag);
-    this.undeployOpers.removeAll(newOpers.keySet());
-    //make sure all the new operators are included in deploy operator list
-    this.deployOpers.addAll(this.newOpers.keySet());
+
+    // redeploy dependencies of the new operators excluding the new operators themselves
+    Set<PTOperator> ndeps = getDependents(this.newOpers.keySet());
+    this.undeployOpers.addAll(ndeps);
+    this.undeployOpers.removeAll(this.newOpers.keySet());
+
     // include downstream dependencies of affected operators into redeploy
     Set<PTOperator> deployOperators = this.getDependents(this.deployOpers);
+    // include new operators and their dependencies for deployment
+    deployOperators.addAll(ndeps);
+
+    //make sure all the new operators are included in deploy operator list
+    this.deployOpers.addAll(this.newOpers.keySet());
+
     ctx.deploy(releaseContainers, this.undeployOpers, newContainers, deployOperators);
     this.newOpers.clear();
     this.deployOpers.clear();

--- a/engine/src/test/java/com/datatorrent/stram/plan/physical/PhysicalPlanTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/plan/physical/PhysicalPlanTest.java
@@ -1514,6 +1514,98 @@ public class PhysicalPlanTest
 
   }
 
+  /**
+   * Test covering scenario when only new partitions are added during dynamic partitioning and there
+   * are no changes to existing partitions and partition mapping
+   */
+  @Test
+  public void testAugmentedDynamicPartitioning()
+  {
+    LogicalPlan dag = new LogicalPlan();
+
+    TestGeneratorInputOperator o1 = dag.addOperator("o1", TestGeneratorInputOperator.class);
+    dag.setAttribute(o1, OperatorContext.PARTITIONER, new TestAugmentingPartitioner<TestGeneratorInputOperator>(3));
+    dag.setAttribute(o1, OperatorContext.STATS_LISTENERS, Lists.newArrayList((StatsListener)new PartitioningTest.PartitionLoadWatch()));
+    OperatorMeta o1Meta = dag.getMeta(o1);
+
+    GenericTestOperator o2 = dag.addOperator("o2", GenericTestOperator.class);
+    OperatorMeta o2Meta = dag.getMeta(o2);
+
+    dag.addStream("o1.outport1", o1.outport, o2.inport1);
+
+    int maxContainers = 10;
+    dag.setAttribute(LogicalPlan.CONTAINERS_MAX_COUNT, maxContainers);
+
+    TestPlanContext ctx = new TestPlanContext();
+    dag.setAttribute(OperatorContext.STORAGE_AGENT, ctx);
+
+    PhysicalPlan plan = new PhysicalPlan(dag, ctx);
+    Assert.assertEquals("number of containers", 5, plan.getContainers().size());
+
+    List<PTOperator> o1ops = plan.getOperators(o1Meta);
+    Assert.assertEquals("number of o1 operators", 3, o1ops.size());
+
+    List<PTOperator> o2ops = plan.getOperators(o2Meta);
+    Assert.assertEquals("number of o2 operators", 1, o2ops.size());
+
+    List<PTOperator> uops = plan.getMergeOperators(o1Meta);
+
+    Set<PTOperator> expUndeploy = Sets.newLinkedHashSet();
+    expUndeploy.addAll(plan.getOperators(o2Meta));
+    expUndeploy.addAll(uops);
+
+    for (int i = 0; i < 2; ++i) {
+      PartitioningTest.PartitionLoadWatch.put(o1ops.get(i), 1);
+      plan.onStatusUpdate(o1ops.get(i));
+    }
+
+    ctx.backupRequests = 0;
+    ctx.events.remove(0).run();
+
+    Assert.assertEquals("number of containers", 7, plan.getContainers().size());
+
+    Assert.assertEquals("undeployed opertors", expUndeploy, ctx.undeploy);
+  }
+
+  private class TestAugmentingPartitioner<T> implements Partitioner<T>
+  {
+
+    int initalPartitionCount = 1;
+
+    private TestAugmentingPartitioner(int initialPartitionCount)
+    {
+      this.initalPartitionCount = initialPartitionCount;
+    }
+
+    @Override
+    public Collection<Partition<T>> definePartitions(Collection<Partition<T>> partitions, PartitioningContext context)
+    {
+      Collection<Partition<T>> newPartitions = Lists.newArrayList(partitions);
+      int numTotal = partitions.size();
+      Partition<T> first = partitions.iterator().next();
+      if (first.getStats() == null) {
+        // Initial partition
+        numTotal = initalPartitionCount;
+      } else {
+        for (Partition<T> p : partitions) {
+          // Assumption load is non-negative
+          numTotal += p.getLoad();
+        }
+      }
+      T paritionable = first.getPartitionedInstance();
+      for (int i = partitions.size(); i < numTotal; ++i) {
+        newPartitions.add(new DefaultPartition<T>(paritionable));
+      }
+      return newPartitions;
+    }
+
+    @Override
+    public void partitioned(Map<Integer, Partition<T>> partitions)
+    {
+
+    }
+  }
+
   @Test
   public void testCascadingUnifier()
   {


### PR DESCRIPTION
Continuing from a previous pull request
https://github.com/apache/incubator-apex-core/pull/314

@tweise @amberarrow please see
