### PR TITLE
APEXCORE-330 : Stacktrace of the StreamingContainer exposed through REST 

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/StreamingContainerAgent.java
+++ b/engine/src/main/java/com/datatorrent/stram/StreamingContainerAgent.java
@@ -96,6 +96,7 @@ public class StreamingContainerAgent
   }
 
   boolean shutdownRequested = false;
+  boolean stackTraceRequested = false;
 
   Set<PTOperator> deployOpers = Sets.newHashSet();
   Set<Integer> undeployOpers = Sets.newHashSet();
@@ -468,4 +469,12 @@ public class StreamingContainerAgent
     return ci;
   }
 
+  public String getStackTrace()
+  {
+
+    stackTraceRequested = true;
+    return containerStackTrace;
+  }
+
+  public volatile String containerStackTrace = null;
 }

--- a/engine/src/main/java/com/datatorrent/stram/StreamingContainerManager.java
+++ b/engine/src/main/java/com/datatorrent/stram/StreamingContainerManager.java
@@ -1489,6 +1489,8 @@ public class StreamingContainerManager implements PlanContext
       });
     }
 
+    sca.containerStackTrace = heartbeat.stackTrace;
+
     if (heartbeat.restartRequested) {
       LOG.error("Container {} restart request", sca.container.getExternalId());
       containerStopRequests.put(sca.container.getExternalId(), sca.container.getExternalId());
@@ -1820,6 +1822,9 @@ public class StreamingContainerManager implements PlanContext
     }
     rsp.nodeRequests = requests;
     rsp.committedWindowId = committedWindowId;
+    rsp.stackTraceRequired = sca.stackTraceRequested;
+    sca.stackTraceRequested = false;
+
     return rsp;
   }
 

--- a/engine/src/main/java/com/datatorrent/stram/api/StreamingContainerUmbilicalProtocol.java
+++ b/engine/src/main/java/com/datatorrent/stram/api/StreamingContainerUmbilicalProtocol.java
@@ -253,6 +253,7 @@ public interface StreamingContainerUmbilicalProtocol extends VersionedProtocol
       return stats.id;
     }
 
+    public String stackTrace;
   }
 
   /**
@@ -380,6 +381,8 @@ public interface StreamingContainerUmbilicalProtocol extends VersionedProtocol
      * Set when dag purges a particular windowId as it's processed by all the operators.
      */
     public long committedWindowId = -1;
+
+    public boolean stackTraceRequired = false;
   }
 
   /**

--- a/engine/src/main/java/com/datatorrent/stram/cli/ApexCli.java
+++ b/engine/src/main/java/com/datatorrent/stram/cli/ApexCli.java
@@ -770,6 +770,10 @@ public class ApexCli
         null,
         new Arg[]{new Arg("operator-id"), new Arg("start-time")},
         "Get tuple recording info"));
+    connectedCommands.put("get-container-stacktrace", new CommandSpec(new GetContainerStackTrace(),
+        null,
+        new Arg[]{new Arg("container-id")},
+        "Get the stack trace for the container"));
 
     //
     // Logical plan change command specification starts here
@@ -3361,6 +3365,28 @@ public class ApexCli
       response.put("state", appReport.getYarnApplicationState().name());
       response.put("trackingUrl", appReport.getTrackingUrl());
       response.put("finalStatus", appReport.getFinalApplicationStatus());
+      printJson(response);
+    }
+
+  }
+
+  private class GetContainerStackTrace implements Command
+  {
+    @Override
+    public void execute(String[] args, ConsoleReader reader) throws Exception
+    {
+      String containerLongId = getContainerLongId(args[1]);
+      if (containerLongId == null) {
+        throw new CliException("Container " + args[1] + " not found");
+      }
+
+      JSONObject response;
+      try {
+        response = getResource(StramWebServices.PATH_PHYSICAL_PLAN_CONTAINERS + "/" + args[1] + "/" + StramWebServices.PATH_STACKTRACE, currentApp);
+      } catch (Exception ex) {
+        throw new CliException("Webservice call to AppMaster failed.", ex);
+      }
+
       printJson(response);
     }
 


### PR DESCRIPTION
Getting stack trace from the containers, exposed through REST api

The return value will in JSON.

StackTrace can be accessed through the following call.
  "/ws/v2/stram/physicalPlan/containers/containersID/stackTrace"
