### PR TITLE
Upgrade Jackson 1.9.2 -> 1.9.13 (latest 1.x patch)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <maven.build.timestamp.format>yyyyMMdd</maven.build.timestamp.format>
     <hadoop.version>2.2.0</hadoop.version>
     <github.global.server>github</github.global.server>
-    <jackson.version>1.9.2</jackson.version>
+    <jackson.version>1.9.13</jackson.version>
     <jersey.version>1.9</jersey.version>
     <!-- do not change jetty version as later versions have problems with DefaultServlet -->
     <jetty.version>8.1.10.v20130312</jetty.version>


### PR DESCRIPTION
Upgrade of Jackson version should be trivially simple since it's patch-level, no API or behavioral change.
Test suite passed before and after the change as well.
