### PR TITLE
*Review only* Prototype of running java utils to get information from containers

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/StramUtils.java
+++ b/engine/src/main/java/com/datatorrent/stram/StramUtils.java
@@ -19,6 +19,7 @@
 package com.datatorrent.stram;
 
 
+import java.io.IOException;
 import java.util.Map;
 
 import org.codehaus.jettison.json.JSONArray;
@@ -31,6 +32,7 @@ import org.apache.hadoop.yarn.api.ApplicationConstants.Environment;
 import org.apache.log4j.DTLoggerFactory;
 
 import com.datatorrent.api.StreamingApplication;
+import com.datatorrent.stram.util.StreamGobbler;
 
 /**
  *
@@ -129,6 +131,39 @@ public abstract class StramUtils
     } catch (JSONException e) {
       throw new RuntimeException(e);
     }
+
+    return jsonObject;
+  }
+
+  public static JSONObject getStackTrace2() throws JSONException
+  {
+
+    String result = "hello";
+    try {
+
+      String processName = java.lang.management.ManagementFactory.getRuntimeMXBean().getName();
+      Long processId = Long.parseLong(processName.split("@")[0]);
+
+      String cmd = "jstack " + processId;
+
+      Runtime rt = Runtime.getRuntime();
+      Process process = rt.exec(cmd);
+
+      StreamGobbler outputGobbler = new StreamGobbler(process.getInputStream());
+
+      outputGobbler.start();
+
+      process.waitFor();
+
+      result = outputGobbler.getContent();
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.put("result", result);
 
     return jsonObject;
   }

--- a/engine/src/main/java/com/datatorrent/stram/engine/StreamingContainer.java
+++ b/engine/src/main/java/com/datatorrent/stram/engine/StreamingContainer.java
@@ -699,7 +699,7 @@ public class StreamingContainer extends YarnContainerMain
         rsp = umbilical.processHeartbeat(msg);
 
         if (rsp.stackTraceRequired) {
-          stackTrace = StramUtils.getStackTrace().toString();
+          stackTrace = StramUtils.getStackTrace2().toString();
         } else {
           stackTrace = null;
         }

--- a/engine/src/main/java/com/datatorrent/stram/webapp/StramWebServices.java
+++ b/engine/src/main/java/com/datatorrent/stram/webapp/StramWebServices.java
@@ -506,7 +506,7 @@ public class StramWebServices
     init();
 
     if (containerId.equals(System.getenv(ApplicationConstants.Environment.CONTAINER_ID.toString()))) {
-      return StramUtils.getStackTrace();
+      return StramUtils.getStackTrace2();
     }
 
     StreamingContainerAgent sca = dagManager.getContainerAgent(containerId);


### PR DESCRIPTION
I am using Jstack to get the container stack. But the idea is to run various commands ( jcmd, jinfo, jstat etc ) and the  user will supply the name of the command and the argument to run. We can have the whitelist of commands to run.

This will expose every information that can be collected from JDK tools.
