### PR TITLE
[APEXCORE-172] Fixed license header in StatefulStreamCodec.java

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/codec/StatefulStreamCodec.java
+++ b/engine/src/main/java/com/datatorrent/stram/codec/StatefulStreamCodec.java
@@ -16,10 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package com.datatorrent.stram.codec;
 
 import com.datatorrent.api.StreamCodec;


### PR DESCRIPTION
- Fixed license header to be correct.
