### PR TITLE
*Review only* [APEXCORE-482]Make the downstream operator & unifier in the same container as THREA…

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/StreamingContainerAgent.java
+++ b/engine/src/main/java/com/datatorrent/stram/StreamingContainerAgent.java
@@ -265,7 +265,9 @@ public class StreamingContainerAgent
           if (!publishers.contains(sourceOutput)) {
             throw new AssertionError("Source not deployed for container local stream " + sourceOutput + " " + in);
           }
-          if (streamMeta.getLocality() == Locality.THREAD_LOCAL) {
+
+          if (streamMeta.getLocality() == Locality.THREAD_LOCAL || in.locality == Locality.THREAD_LOCAL) {
+
             inputInfo.locality = Locality.THREAD_LOCAL;
             ndi.type = OperatorType.OIO;
           } else {

--- a/engine/src/main/java/com/datatorrent/stram/plan/physical/PTOperator.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/physical/PTOperator.java
@@ -85,6 +85,7 @@ public class PTOperator implements java.io.Serializable
     private static final long serialVersionUID = 201312112033L;
 
     public final LogicalPlan.StreamMeta logicalStream;
+    public Locality locality;
     public final PTOperator target;
     public final PartitionKeys partitions;
     public final PTOutput source;

--- a/engine/src/main/java/com/datatorrent/stram/plan/physical/PhysicalPlan.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/physical/PhysicalPlan.java
@@ -73,6 +73,7 @@ import com.datatorrent.stram.Journal.Recoverable;
 import com.datatorrent.stram.api.Checkpoint;
 import com.datatorrent.stram.api.StramEvent;
 import com.datatorrent.stram.api.StreamingContainerUmbilicalProtocol.StramToNodeRequest;
+import com.datatorrent.stram.engine.DefaultUnifier;
 import com.datatorrent.stram.plan.logical.LogicalPlan;
 import com.datatorrent.stram.plan.logical.LogicalPlan.InputPortMeta;
 import com.datatorrent.stram.plan.logical.LogicalPlan.OperatorMeta;
@@ -463,6 +464,19 @@ public class PhysicalPlan implements Serializable
       }
     }
 
+    for (PTContainer ptContainer: containers) {
+      if (ptContainer.getOperators().size() > 1) {
+        for (PTOperator operator: ptContainer.getOperators()) {
+          for (PTInput ptInput: operator.getInputs()) {
+            if (ptInput.source.source.getOperatorMeta().getOperator() instanceof DefaultUnifier) {
+              if (ptInput.source.source.container == operator.container) {
+                ptInput.locality = Locality.THREAD_LOCAL;
+              }
+            }
+          }
+        }
+      }
+    }
     
     for (PTContainer container : containers) {
       updateContainerMemoryWithBufferServer(container);


### PR DESCRIPTION
…D_LOCAL

Opening it early, to get the feedback on the approach.

Note:
Added the locality field. The reason for that is StreamMeta is shared with the upstream operator, so changing the locality in the Unifier affects the upstream as well, but it is not required.

TODO: Add unit tests
