### PR TITLE
APEXCORE-495 supporting apps in config package.

### DIFF
--- a/apex-conf-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/apex-conf-archetype/src/main/resources/archetype-resources/pom.xml
@@ -25,6 +25,7 @@
     <apex.apppackage.maxversion>1.9999.9999</apex.apppackage.maxversion>
     <apex.appconf.classpath>classpath/*</apex.appconf.classpath>
     <apex.appconf.files>files/*</apex.appconf.files>
+    <apex.appconf.app>app/*</apex.appconf.app>
   </properties>
 
   <build>

--- a/apex-conf-archetype/src/main/resources/archetype-resources/src/assemble/confPackage.xml
+++ b/apex-conf-archetype/src/main/resources/archetype-resources/src/assemble/confPackage.xml
@@ -19,6 +19,10 @@
       <directory>${basedir}/src/main/resources/files</directory>
       <outputDirectory>/files</outputDirectory>
     </fileSet>
+    <fileSet>
+      <directory>${basedir}/src/main/resources/app</directory>
+      <outputDirectory>/app</outputDirectory>
+    </fileSet>
   </fileSets>
 
 </assembly>

--- a/engine/src/test/java/com/datatorrent/stram/cli/ApexCliTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/cli/ApexCliTest.java
@@ -22,8 +22,10 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -35,7 +37,7 @@ import com.datatorrent.stram.client.ConfigPackage;
 import com.datatorrent.stram.client.DTConfiguration;
 import com.datatorrent.stram.support.StramTestSupport;
 
-import static com.datatorrent.stram.support.StramTestSupport.setEnv;
+import jline.console.ConsoleReader;
 
 /**
  *
@@ -52,33 +54,31 @@ public class ApexCliTest
   private static File appFile;
   private static File configFile;
 
-
-  private static AppPackage ap;
-  private static ConfigPackage cp;
+  private AppPackage ap;
+  private ConfigPackage cp;
   static TemporaryFolder testFolder = new TemporaryFolder();
-  static ApexCli cli = new ApexCli();
+  ApexCli cli;
 
   static Map<String, String> env = new HashMap<String, String>();
   static String userHome;
 
   @BeforeClass
-  public static void starting()
+  public static void createPackages()
   {
+    userHome = System.getProperty("user.home");
+    String newHome = System.getProperty("user.dir") + "/target";
     try {
-      userHome = System.getProperty("user.home");
-      String newHome = System.getProperty("user.dir") + "/target";
+
       FileUtils.forceMkdir(new File(newHome + "/.dt"));
       FileUtils.copyFile(new File(System.getProperty("user.dir") + "/src/test/resources/testAppPackage/dt-site.xml"), new File(newHome + "/.dt/dt-site.xml"));
       env.put("HOME", newHome);
-      setEnv(env);
-
-      cli.init();
+      StramTestSupport.setEnv(env);
       // Set up jar file to use with constructor
       testFolder.create();
+
       appFile = StramTestSupport.createAppPackageFile();
       configFile = StramTestSupport.createConfigPackageFile(new File(testFolder.getRoot(), configJarPath));
-      ap = new AppPackage(appFile, true);
-      cp = new ConfigPackage(configFile);
+
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -88,15 +88,36 @@ public class ApexCliTest
   public static void finished()
   {
     try {
-      env.put("HOME", userHome);
-      setEnv(env);
-
+      
       StramTestSupport.removeAppPackageFile();
       FileUtils.forceDelete(configFile);
       testFolder.delete();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Before
+  public void startingTest()
+  {
+    try {
+
+      cli = new ApexCli();
+      cli.init();
+
+      ap = new AppPackage(appFile, true);
+      cp = new ConfigPackage(configFile);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @After
+  public void finishedTest()
+  {
+    ap = null;
+    cp = null;
+    cli = null;
   }
 
   @Test
@@ -128,6 +149,9 @@ public class ApexCliTest
   {
     ApexCli.LaunchCommandLineInfo commandLineInfo = ApexCli
         .getLaunchCommandLineInfo(new String[]{"-exactMatch", "-conf", configFile.getAbsolutePath(), appFile.getAbsolutePath(), "MyFirstApplication"});
+
+    commandLineInfo.args = new String[] {"MyFirstApplication"};
+
     String[] args = cli.getLaunchAppPackageArgs(ap, cp, commandLineInfo, null);
     commandLineInfo = ApexCli.getLaunchCommandLineInfo(args);
     StringBuilder sb = new StringBuilder();
@@ -179,5 +203,43 @@ public class ApexCliTest
     Assert.assertEquals("user-home-config", props.get("dt.test.4"));
     Assert.assertEquals("app-default", props.get("dt.test.5"));
     Assert.assertEquals("package-default", props.get("dt.test.6"));
+  }
+
+  @Test
+  public void testAppFromOnlyConfigPackage() throws Exception
+  {
+    ApexCli.LaunchCommandLineInfo commandLineInfo = ApexCli
+        .getLaunchCommandLineInfo(new String[]{"-conf", configFile.getAbsolutePath(), appFile.getAbsolutePath(), "-useConfigApps", "exclusive"});
+
+    ApexCli apexCli = new ApexCli();
+    apexCli.init();
+
+    Assert.assertEquals("configApps", "exclusive", commandLineInfo.useConfigApps);
+
+    apexCli.getLaunchAppPackageArgs(ap, cp, commandLineInfo, new ConsoleReader());
+
+    Assert.assertEquals(ap.getApplications().size(), 1);
+    Assert.assertEquals(ap.getApplications().get(0).displayName, "testApp");
+    Assert.assertEquals(ap.getApplications().get(0).type, "json");
+  }
+
+  @Test
+  public void testMergeAppFromConfigAndAppPackage() throws Exception
+  {
+    ApexCli.LaunchCommandLineInfo commandLineInfo = ApexCli
+        .getLaunchCommandLineInfo(new String[]{"-conf", configFile.getAbsolutePath(), appFile.getAbsolutePath(), "-useConfigApps", "inclusive"});
+
+    Assert.assertEquals("configApps", "inclusive", commandLineInfo.useConfigApps);
+
+    ApexCli apexCli = new ApexCli();
+    apexCli.init();
+
+    try {
+      apexCli.getLaunchAppPackageArgs(ap, cp, commandLineInfo, new ConsoleReader());
+    } catch (ApexCli.CliException cliException) {
+      return;
+    }
+
+    Assert.fail("Cli failed throw multiple apps exception.");
   }
 }

--- a/engine/src/test/resources/testConfigPackage/testConfigPackageSrc/app/testApp.json
+++ b/engine/src/test/resources/testConfigPackage/testConfigPackageSrc/app/testApp.json
@@ -1,0 +1,53 @@
+{
+  "displayName":"testApp",
+  "attributes":{
+
+  },
+  "operators":[
+    {
+      "name":"Operator 1",
+      "attributes":{
+
+      },
+      "class":"org.apache.apex.test.DevNull",
+      "ports":[
+        {
+          "name":"inputPort",
+          "attributes":{
+
+          }
+        }
+      ]
+    },
+    {
+      "name":"Operator 2",
+      "attributes":{
+
+      },
+      "class":"org.apache.apex.test.RandomGen",
+      "ports":[
+        {
+          "name":"out",
+          "attributes":{
+
+          }
+        }
+      ]
+    }
+  ],
+  "streams":[
+    {
+      "name":"Stream 1",
+      "sinks":[
+        {
+          "operatorName":"Operator 1",
+          "portName":"inputPort"
+        }
+      ],
+      "source":{
+        "operatorName":"Operator 2",
+        "portName":"out"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
1. Added support to store apps in the config file
2. By default apps from the config and app package gets merged (During conflict Config apps overwrite the AppPackage apps)
3. New option during launch, "useConfigApps" - will take either of "inclusive"/"exclusive"
   "inclusive" - merge the apps present in app & config package and the config package apps overwrite the conflicting the apps
   "exclusive" - show only config apps
   If the user do not specify "useConfigApps" only the apps present in the app package is shown.
