### PR TITLE
APEXCORE-474 - Unifier placement during M*1 case.

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/plan/physical/StreamMapping.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/physical/StreamMapping.java
@@ -293,7 +293,7 @@ public class StreamMapping implements java.io.Serializable
               }
             }
           }
-          if (!separateUnifiers && ((pks == null || pks.mask == 0) || lastSingle)) {
+          if (!separateUnifiers && lastSingle) {
             if (finalUnifier == null) {
               finalUnifier = createUnifier(streamMeta, plan);
             }
@@ -307,6 +307,11 @@ public class StreamMapping implements java.io.Serializable
           } else {
             // MxN partitioning: unifier per downstream partition
             LOG.debug("MxN unifier for {} {} {}", new Object[] {doperEntry.first, doperEntry.second.getPortName(), pks});
+
+            if (pks != null && pks.mask == 0) {
+              pks = null;
+            }
+
             PTOperator unifier = doperEntry.first.upstreamMerge.get(doperEntry.second);
             if (unifier == null) {
               unifier = createUnifier(streamMeta, plan);

--- a/engine/src/test/java/com/datatorrent/stram/LocalityTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/LocalityTest.java
@@ -73,7 +73,7 @@ public class LocalityTest
     dag.setAttribute(LogicalPlan.CONTAINERS_MAX_COUNT, maxContainers);
 
     StreamingContainerManager scm = new StreamingContainerManager(dag);
-    Assert.assertEquals("number required containers", 7, scm.containerStartRequests.size());
+    Assert.assertEquals("number required containers", 6, scm.containerStartRequests.size());
 
     ResourceRequestHandler rr = new ResourceRequestHandler();
 

--- a/engine/src/test/java/com/datatorrent/stram/PartitioningTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/PartitioningTest.java
@@ -298,7 +298,7 @@ public class PartitioningTest
     for (PTOperator oper : partitions) {
       containers.add(oper.getContainer());
     }
-    Assert.assertTrue("Number of containers are 5", 5 == lc.dnmgr.getPhysicalPlan().getContainers().size());
+    Assert.assertTrue("Number of containers are 4", 4 == lc.dnmgr.getPhysicalPlan().getContainers().size());
 
     PTOperator splitPartition = partitions.get(0);
     PartitionLoadWatch.put(splitPartition, 1);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/APEXCORE-474

Creating a separate container for the last unifier is not required. It only changes the default behavior, users can still create the separate containers for unifiers.

@PramodSSImmaneni & @tweise please review.
