### PR TITLE
APEXCORE-525 fail validation if statefull streamcodec does not implement newInstance method.

### DIFF
--- a/bufferserver/src/main/java/com/datatorrent/bufferserver/internal/LogicalNode.java
+++ b/bufferserver/src/main/java/com/datatorrent/bufferserver/internal/LogicalNode.java
@@ -32,8 +32,8 @@ import com.datatorrent.bufferserver.policy.Policy;
 import com.datatorrent.bufferserver.util.BitVector;
 import com.datatorrent.bufferserver.util.Codec;
 import com.datatorrent.bufferserver.util.SerializedData;
-import com.datatorrent.netlet.AbstractLengthPrependerClient;
 import com.datatorrent.netlet.EventLoop;
+import com.datatorrent.netlet.WriteOnlyClient;
 
 /**
  * LogicalNode represents a logical node in a DAG<p>
@@ -99,7 +99,7 @@ public class LogicalNode implements DataListener
    *
    * @param connection
    */
-  public void addConnection(AbstractLengthPrependerClient connection)
+  public void addConnection(WriteOnlyClient connection)
   {
     PhysicalNode pn = new PhysicalNode(connection);
     if (!physicalNodes.contains(pn)) {
@@ -111,7 +111,7 @@ public class LogicalNode implements DataListener
    *
    * @param client
    */
-  public void removeChannel(AbstractLengthPrependerClient client)
+  public void removeChannel(WriteOnlyClient client)
   {
     for (PhysicalNode pn : physicalNodes) {
       if (pn.getClient() == client) {

--- a/engine/src/main/java/com/datatorrent/stram/codec/DefaultStatefulStreamCodec.java
+++ b/engine/src/main/java/com/datatorrent/stram/codec/DefaultStatefulStreamCodec.java
@@ -232,7 +232,11 @@ public class DefaultStatefulStreamCodec<T> extends Kryo implements StatefulStrea
   @Override
   public DefaultStatefulStreamCodec<T> newInstance()
   {
-    return new DefaultStatefulStreamCodec<>();
+    try {
+      return getClass().newInstance();
+    } catch (InstantiationException | IllegalAccessException e) {
+      throw new RuntimeException("Unable to create new stateful streamcodec object", e);
+    }
   }
 
   private static final Logger logger = LoggerFactory.getLogger(DefaultStatefulStreamCodec.class);

--- a/engine/src/test/java/com/datatorrent/stram/codec/DefaultStatefulStreamCodecTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/codec/DefaultStatefulStreamCodecTest.java
@@ -214,4 +214,17 @@ public class DefaultStatefulStreamCodecTest
     }
   }
 
+  static class NoNewInstanceStatefulStreamCodec<T> extends DefaultStatefulStreamCodec<T>
+  {
+
+  }
+
+  @Test
+  public void testNewInstanceMethod()
+  {
+    NoNewInstanceStatefulStreamCodec codec = new NoNewInstanceStatefulStreamCodec();
+    DefaultStatefulStreamCodec newCodec = codec.newInstance();
+    Assert.assertNotEquals("Codec and newCodec are not same ", codec, newCodec);
+    Assert.assertEquals("Class of codec and newCodec is same ", newCodec.getClass(), codec.getClass());
+  }
 }


### PR DESCRIPTION
If user implements a streamcodec extending DefaultStatefulStreamCodec they need to also remember to implement newInstance method as platform use object returned by newInstance as codec. If use forget to override newInstance then  platform keep on using default codec without any warning to user and
such error are caught very late mostly resulting incorrect data distribution and incorrect result at final
operator.
