### PR TITLE
APEXCORE-408 Ability to schedule Sub-DAG from running application

### DIFF
--- a/api/src/main/java/com/datatorrent/api/DAG.java
+++ b/api/src/main/java/com/datatorrent/api/DAG.java
@@ -288,4 +288,23 @@ public interface DAG extends DAGContext, Serializable
   {
 
   }
+
+  /**
+   * This class provides functionality to extend existing DAG. The type of extensions allowed are
+   *
+   * <li>Add a new operator</li>
+   * <li>Remove an existing operator</li>
+   * <li>Add an operator to stream</li>
+   * <li>Add an stream between existing operator and new opeartor</li>
+   */
+  interface DAGChangeSet extends DAG
+  {
+    void removeOperator(String name);
+
+    void removeStream(String name);
+
+    StreamMeta extendStream(String id, Operator.InputPort... ports);
+
+    StreamMeta addStream(String id, String operatorName, String portName, Operator.InputPort... ports);
+  }
 }

--- a/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlan.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlan.java
@@ -1017,7 +1017,7 @@ public class LogicalPlan implements Serializable, DAG
      *
      * @param operatorMeta copy attribute from this OperatorMeta to the object.
      */
-    private void copyAttributesFrom(OperatorMeta operatorMeta)
+    public void copyAttributesFrom(OperatorMeta operatorMeta)
     {
       if (operator != operatorMeta.getOperator()) {
         throw new IllegalArgumentException("Operator meta is not for the same operator ");

--- a/engine/src/main/java/com/datatorrent/stram/plan/logical/mod/DAGChangeSetImpl.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/logical/mod/DAGChangeSetImpl.java
@@ -1,0 +1,269 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.datatorrent.stram.plan.logical.mod;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+
+import com.google.common.collect.Maps;
+
+import com.datatorrent.api.DAG;
+import com.datatorrent.api.DAG.DAGChangeSet;
+import com.datatorrent.api.Operator;
+import com.datatorrent.stram.plan.logical.LogicalPlan;
+
+/**
+ * An implementation for DAGChangeSet. Instance of this object will be provided
+ * to StatsListener through context, stat listener can use this object to modify
+ * existing DAG and return modified DAG to engine.
+ */
+public class DAGChangeSetImpl extends LogicalPlan implements DAGChangeSet
+{
+  private List<String> removedOperators = new ArrayList<>();
+  private List<String> removedStreams = new ArrayList<>();
+
+  public void removeOperator(String name)
+  {
+    removedOperators.add(name);
+  }
+
+  public void removeStream(String name)
+  {
+    removedStreams.add(name);
+  }
+
+  public List<LogicalPlan.OperatorMeta> getOperatorsInOrder()
+  {
+    List<LogicalPlan.OperatorMeta> operators = new ArrayList<>();
+    Set<LogicalPlan.OperatorMeta> added = new HashSet<>();
+
+    Stack<LogicalPlan.OperatorMeta> pendingNodes = new Stack<>();
+
+    for (LogicalPlan.OperatorMeta n : getAllOperators()) {
+      pendingNodes.push(n);
+    }
+
+    while (!pendingNodes.isEmpty()) {
+      LogicalPlan.OperatorMeta n = pendingNodes.pop();
+
+      if (added.contains(n)) {
+        // already processed as upstream dependency
+        continue;
+      }
+
+      boolean upstreamDeployed = true;
+
+      for (Map.Entry<LogicalPlan.InputPortMeta, LogicalPlan.StreamMeta> entry : n.getInputStreams().entrySet()) {
+        LogicalPlan.StreamMeta s = entry.getValue();
+        boolean delay = entry.getKey().getValue(IS_CONNECTED_TO_DELAY_OPERATOR);
+        // skip delay sources since it's going to be handled as downstream
+        if (!delay && s.getSource() != null && !added.contains(s.getSource().getOperatorMeta())) {
+          pendingNodes.push(n);
+          pendingNodes.push(s.getSource().getOperatorMeta());
+          upstreamDeployed = false;
+          break;
+        }
+      }
+
+      if (upstreamDeployed) {
+        added.add(n);
+        operators.add(n);
+      }
+    }
+    return operators;
+  }
+
+  public List<String> getRemovedOperators()
+  {
+    return removedOperators;
+  }
+
+  public List<String> getRemovedStreams()
+  {
+    return removedStreams;
+  }
+
+  /**
+   * Base class for StreamMeta object which modify existing stream or
+   * add new stream to the DAG with one end point in the existing stream.
+   */
+  public static class ExtendStreamMeta implements DAG.StreamMeta
+  {
+    /** name of the stream to change */
+    private String name;
+    /** new additional sinks to add in stream */
+    private Set<Operator.InputPort> sinkPorts = new HashSet<>();
+
+    public ExtendStreamMeta(String id)
+    {
+      this.name = id;
+    }
+
+    @Override
+    public String getName()
+    {
+      return name;
+    }
+
+    @Override
+    public Locality getLocality()
+    {
+      throw new UnsupportedOperationException("Can not get locality of the existing stream");
+    }
+
+    public DAG.StreamMeta setLocality(Locality locality)
+    {
+      throw new UnsupportedOperationException("Can not change locality of existing stream");
+    }
+
+    @Override
+    public DAG.StreamMeta setSource(Operator.OutputPort<?> port)
+    {
+      throw new UnsupportedOperationException("Can not set source of the existing stream");
+    }
+
+    @Override
+    public DAG.StreamMeta addSink(Operator.InputPort<?> port)
+    {
+      sinkPorts.add(port);
+      return this;
+    }
+
+    @Override
+    public DAG.StreamMeta persistUsing(String name, Operator persistOperator, Operator.InputPort<?> persistOperatorInputPort)
+    {
+      throw new UnsupportedOperationException("persist using operation is not supported");
+    }
+
+    @Override
+    public DAG.StreamMeta persistUsing(String name, Operator persistOperator)
+    {
+      throw new UnsupportedOperationException("persist using operation is not supported");
+    }
+
+    @Override
+    public DAG.StreamMeta persistUsing(String name, Operator persistOperator, Operator.InputPort<?> persistOperatorInputPort, Operator.InputPort<?> sinkToPersist)
+    {
+      return null;
+    }
+
+    public Set<Operator.InputPort> getSinkPorts()
+    {
+      return sinkPorts;
+    }
+
+  }
+
+  /**
+   * StreamMeta for modification which add a new stream with one end in
+   * already existing DAG, and other end is specified as port.
+   */
+  public static class StreamExtendBySource extends ExtendStreamMeta
+  {
+    private String operatorName;
+    private String portName;
+
+    public StreamExtendBySource(String id, String operator, String port)
+    {
+      super(id);
+      this.operatorName = operator;
+      this.portName = port;
+    }
+
+    public String getOperatorName()
+    {
+      return operatorName;
+    }
+
+    public void setOperatorName(String operatorName)
+    {
+      this.operatorName = operatorName;
+    }
+
+    public String getPortName()
+    {
+      return portName;
+    }
+
+    public void setPortName(String portName)
+    {
+      this.portName = portName;
+    }
+  }
+
+  private Map<String, DAG.StreamMeta> extendStreams = Maps.newHashMap();
+
+  public Map<String, DAG.StreamMeta> getExtendStreams()
+  {
+    return extendStreams;
+  }
+
+  DAG.StreamMeta getExtendStreams(String id)
+  {
+    DAG.StreamMeta sm = getStream(id);
+    if (sm == null) {
+      sm = extendStreams.get(id);
+    }
+    if (sm == null) {
+      sm = new ExtendStreamMeta(id);
+      extendStreams.put(id, sm);
+    }
+    return sm;
+  }
+
+  /**
+   * Extend stream present in original DAG with new Sinks.
+   */
+  @Override
+  public DAG.StreamMeta extendStream(String id, Operator.InputPort... ports)
+  {
+    DAG.StreamMeta sm = getExtendStreams(id);
+    for (Operator.InputPort port : ports) {
+      sm.addSink(port);
+    }
+    return sm;
+  }
+
+  /**
+   * Add stream to existing DAG which one end-point belong to operator already existing in
+   * original DAG.
+   */
+  @Override
+  public DAG.StreamMeta addStream(String id, String operatorName, String portName, Operator.InputPort... ports)
+  {
+    DAG.StreamMeta sm = getStream(id);
+    if (sm != null) {
+      throw new IllegalStateException("Stream already connected " + sm);
+    }
+    sm = extendStreams.get(id);
+    if (sm != null) {
+      throw new IllegalStateException("Stream already exists");
+    }
+    sm = new StreamExtendBySource(id, operatorName, portName);
+    extendStreams.put(id, sm);
+    for (Operator.InputPort port : ports) {
+      sm.addSink(port);
+    }
+    return sm;
+  }
+}

--- a/engine/src/test/java/com/datatorrent/stram/LogicalPlanModificationTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/LogicalPlanModificationTest.java
@@ -237,8 +237,8 @@ public class LogicalPlanModificationTest
     Assert.assertTrue("operators " + dag.getAllOperators(), dag.getAllOperators().containsAll(Sets.newHashSet(o1Meta, o3Meta)));
 
     try {
-      plan.getOperators(o2Meta);
-      Assert.fail("removed from physical plan: " + o2Meta);
+      List<PTOperator> operators = plan.getOperators(o2Meta);
+      Assert.assertNull("removed from physical plan " + o2Meta, operators);
     } catch (Exception e) {
       // all good
     }

--- a/engine/src/test/java/com/datatorrent/stram/engine/InputOperatorTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/engine/InputOperatorTest.java
@@ -33,6 +33,7 @@ import com.datatorrent.api.DefaultInputPort;
 import com.datatorrent.api.DefaultOutputPort;
 import com.datatorrent.api.InputOperator;
 import com.datatorrent.api.Operator;
+import com.datatorrent.api.annotation.OutputPortFieldAnnotation;
 import com.datatorrent.common.util.AsyncFSStorageAgent;
 import com.datatorrent.common.util.BaseOperator;
 import com.datatorrent.netlet.util.CircularBuffer;
@@ -51,10 +52,13 @@ public class InputOperatorTest
 
   public static class EvenOddIntegerGeneratorInputOperator implements InputOperator, com.datatorrent.api.Operator.ActivationListener<OperatorContext>
   {
+    @OutputPortFieldAnnotation(optional = true)
     public final transient DefaultOutputPort<Integer> even = new DefaultOutputPort<Integer>();
+    @OutputPortFieldAnnotation(optional = true)
     public final transient DefaultOutputPort<Integer> odd = new DefaultOutputPort<Integer>();
     private final transient CircularBuffer<Integer> evenBuffer = new CircularBuffer<Integer>(1024);
     private final transient CircularBuffer<Integer> oddBuffer = new CircularBuffer<Integer>(1024);
+
     private volatile Thread dataGeneratorThread;
 
     @Override

--- a/engine/src/test/java/com/datatorrent/stram/plan/TestPlanContext.java
+++ b/engine/src/test/java/com/datatorrent/stram/plan/TestPlanContext.java
@@ -21,17 +21,20 @@ package com.datatorrent.stram.plan;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.FutureTask;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
+import com.datatorrent.api.DAG;
 import com.datatorrent.api.Stats.OperatorStats;
 import com.datatorrent.api.StatsListener;
 import com.datatorrent.api.StorageAgent;
@@ -43,7 +46,7 @@ import com.datatorrent.stram.plan.physical.PTContainer;
 import com.datatorrent.stram.plan.physical.PTOperator;
 import com.datatorrent.stram.plan.physical.PhysicalPlan.PlanContext;
 
-public class TestPlanContext implements PlanContext, StorageAgent
+public class TestPlanContext implements PlanContext, StorageAgent, Serializable
 {
   public List<Runnable> events = new ArrayList<Runnable>();
   public Collection<PTOperator> undeploy;
@@ -187,6 +190,12 @@ public class TestPlanContext implements PlanContext, StorageAgent
     {
       return null;
     }
+
   }
 
+  @Override
+  public FutureTask<Object> addDagChangeRequests(DAG.DAGChangeSet dag)
+  {
+    return null;
+  }
 }


### PR DESCRIPTION
Pull request for dynamic dag modification through stats listener.  It provides following
functionality
- StatsListener can access the opearator name for easily detecting which opearator stats are being processed.
- StatsListener can create a instance of object through which it can submit dag modifications to the engine.
- StatsListener can return dag changes as a response to engine.
- PlanModifier is modified to take a DAG and apply it on the existing running DAG and deploy the changes.

The following functionality is not working yet.
- The new opearator does not start from the correct windowId (https://issues.apache.org/jira/browse/APEXCORE-532)
- Relanched application failed to start when it was killed after dynamic dag modification.
- There is no support for resuming operator from previous state when they were removed. This could be achived through
  readig state through external storage on setup.
- persist operator support is not present for newly added streams.
- Not all parts are covered through tests.

The demo application using the feature is available at
https://github.com/tushargosavi/apex-dynamic-scheduling

There are two variations of WordCount application. The first variation detects the presence of
new files start a disconnected DAG to process the data.
(https://github.com/tushargosavi/apex-dynamic-scheduling/blob/master/src/main/java/com/datatorrent/wordcount/WordCountApp.java)

The second application (https://github.com/tushargosavi/apex-dynamic-scheduling/blob/master/src/main/java/com/datatorrent/wordcount/ExtendApp.java),
initially only one reader operator is running in the DAG, and provides pendingFiles as auto-metric to stat listener.
On detecting pending files it attaches splitter counter and output operator to the read operator. Once files are processed the splitter, counter and
output operators are removed and added back again if new data files are added into the directory.
