### PR TITLE
APEXCORE-532: Fix issue where new operators added to dag starts from initial checkpoint

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/plan/physical/PhysicalPlan.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/physical/PhysicalPlan.java
@@ -781,7 +781,7 @@ public class PhysicalPlan implements Serializable
     // create operator instance per partition
     Map<Integer, Partition<Operator>> operatorIdToPartition = Maps.newHashMapWithExpectedSize(partitions.size());
     for (Partition<Operator> partition : partitions) {
-      PTOperator p = addPTOperator(m, partition, Checkpoint.INITIAL_CHECKPOINT);
+      PTOperator p = addPTOperator(m, partition, null);
       operatorIdToPartition.put(p.getId(), partition);
     }
 
@@ -1268,10 +1268,11 @@ public class PhysicalPlan implements Serializable
       Checkpoint activationCheckpoint = Checkpoint.INITIAL_CHECKPOINT;
       for (PTInput input : oper.inputs) {
         PTOperator sourceOper = input.source.source;
+        Checkpoint checkpoint = sourceOper.recoveryCheckpoint;
         if (sourceOper.checkpoints.isEmpty()) {
-          getActivationCheckpoint(sourceOper);
+          checkpoint = getActivationCheckpoint(sourceOper);
         }
-        activationCheckpoint = Checkpoint.max(activationCheckpoint, sourceOper.recoveryCheckpoint);
+        activationCheckpoint = Checkpoint.max(activationCheckpoint, checkpoint);
       }
       return activationCheckpoint;
     }

--- a/engine/src/test/java/com/datatorrent/stram/plan/physical/PhysicalPlanTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/plan/physical/PhysicalPlanTest.java
@@ -710,11 +710,13 @@ public class PhysicalPlanTest
     Assert.assertEquals("unifier activation checkpoint " + o1Meta, 3, o1NewUnifiers.get(0).recoveryCheckpoint.windowId);
   }
 
-  private void setActivationCheckpoint(PTOperator oper, long windowId)
+  public static void setActivationCheckpoint(PTOperator oper, long windowId)
   {
     try {
       oper.operatorMeta.getValue(OperatorContext.STORAGE_AGENT).save(oper.operatorMeta.getOperator(), oper.id, windowId);
-      oper.setRecoveryCheckpoint(new Checkpoint(3, 0, 0));
+      Checkpoint cp = new Checkpoint(windowId, 0, 0);
+      oper.setRecoveryCheckpoint(cp);
+      oper.checkpoints.add(cp);
     } catch (Exception e) {
       Assert.fail(e.toString());
     }


### PR DESCRIPTION
In case new operators are added dynamically, they should start from windowId of upstream operator. The issue was that new operators gets added using addLogicalOpeartor which sets recoveryWindowId to INITIAL_CHECKPOINT, which prevents getActivationCheckpoint to return correct window id of the operator during deploy.

@PramodSSImmaneni  please review.
