### PR TITLE
APEXCORE-542 - Fix debug level verbose option for Apex cli.

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/cli/ApexCli.java
+++ b/engine/src/main/java/com/datatorrent/stram/cli/ApexCli.java
@@ -1105,6 +1105,13 @@ public class ApexCli
         org.apache.log4j.Logger.getRootLogger(),
         org.apache.log4j.Logger.getLogger(ApexCli.class)
     }) {
+
+     /*
+      * Override logLevel specified by user, the same logLevel would be inherited by all
+      * appenders related to logger.
+      */
+      logger.setLevel(logLevel);
+
       @SuppressWarnings("unchecked")
       Enumeration<Appender> allAppenders = logger.getAllAppenders();
       while (allAppenders.hasMoreElements()) {


### PR DESCRIPTION
This changes fixes the debug level console logging for Apex cli.

The default logger level is INFO level for Apex cli. So  even if we specify the threshold level as DEBUG for ConsoleAppender, the default parent level less that the Console Appender level. Hence it is not considered for logging. 
Fix is that logger level is set to DEBUG initially and threshold level for ConsoleAppender is set as per the argument passed to Apex Cli.

Note: Current two appenders are used Event and Console Appenders.

For instrumentation details and unit testing please find the attached file.
[Uploading apex-cli-debug-verbose-fix.log…]()

[apex-cli-debug-verbose-fix.txt](https://github.com/apache/apex-core/files/506397/apex-cli-debug-verbose-fix.txt)
