### PR TITLE
APEXCORE-408: Ability to schedule Sub-DAG from running application.

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/plan/physical/PTOperator.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/physical/PTOperator.java
@@ -255,7 +255,7 @@ public class PTOperator implements java.io.Serializable
   Checkpoint recoveryCheckpoint;
   public int failureCount = 0;
   public int loadIndicator = 0;
-  public List<? extends StatsListener> statsListeners;
+  public List<? extends StatsListener.StatsListenerWithContext> statsListeners;
   public final OperatorStatus stats;
 
   final Map<Locality, HostOperatorSet> groupings = Maps.newHashMapWithExpectedSize(3);

--- a/engine/src/main/java/com/datatorrent/stram/plan/physical/PhysicalPlan.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/physical/PhysicalPlan.java
@@ -36,11 +36,13 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.commons.lang.SerializationUtils;
 import org.apache.commons.lang.StringUtils;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -56,6 +58,7 @@ import com.datatorrent.api.Context;
 import com.datatorrent.api.Context.DAGContext;
 import com.datatorrent.api.Context.OperatorContext;
 import com.datatorrent.api.Context.PortContext;
+import com.datatorrent.api.DAG;
 import com.datatorrent.api.DAG.Locality;
 import com.datatorrent.api.DefaultPartition;
 import com.datatorrent.api.Operator;
@@ -65,6 +68,8 @@ import com.datatorrent.api.Partitioner.Partition;
 import com.datatorrent.api.Partitioner.PartitionKeys;
 import com.datatorrent.api.StatsListener;
 import com.datatorrent.api.StatsListener.OperatorRequest;
+import com.datatorrent.api.StatsListener.StatsListenerContext;
+import com.datatorrent.api.StatsListener.StatsListenerWithContext;
 import com.datatorrent.api.StorageAgent;
 import com.datatorrent.api.StreamCodec;
 import com.datatorrent.api.annotation.Stateless;
@@ -137,6 +142,10 @@ public class PhysicalPlan implements Serializable
 
   private final AtomicInteger strCodecIdSequence = new AtomicInteger();
   private final Map<StreamCodec<?>, Integer> streamCodecIdentifiers = Maps.newHashMap();
+  private StatsListenerContext statsListenerContext = new StatsListenerContextImpl();
+
+  /* pending dag change request */
+  private transient DAG pendingDagChangeRequest = null;
 
   private PTContainer getContainer(int index)
   {
@@ -188,9 +197,14 @@ public class PhysicalPlan implements Serializable
     void writeJournal(Recoverable operation);
 
     void addOperatorRequest(PTOperator oper, StramToNodeRequest request);
+
+    FutureTask<Object> addDagChangeRequests(DAG dag);
   }
 
-  private static class StatsListenerProxy implements StatsListener, Serializable
+  /**
+   * Adapter for handling operator implementing StatsListener interface.
+   */
+  private static class StatsListenerProxy implements StatsListenerWithContext, Serializable
   {
     private static final long serialVersionUID = 201312112033L;
     private final OperatorMeta om;
@@ -205,6 +219,53 @@ public class PhysicalPlan implements Serializable
     {
       return ((StatsListener)om.getOperator()).processStats(stats);
     }
+
+    @Override
+    public Response processStats(BatchedOperatorStats stats, StatsListenerContext context)
+    {
+      StatsListener listener = (StatsListener)om.getOperator();
+      if (listener instanceof StatsListenerWithContext) {
+        return ((StatsListenerWithContext)listener).processStats(stats, context);
+      } else {
+        return processStats(stats);
+      }
+    }
+  }
+
+  /**
+   * Adapter for handling deprecated StatsListener. This implementation calls {@see StatsListener.processStats(BatchedOperatorStats)}
+   * of the old stats listener ignoring context.
+   */
+  private static class StatsListenerAdapterForStatsListener implements  StatsListener.StatsListenerWithContext, Serializable
+  {
+    private static final long serialVersionUID = 201312112345033L;
+    private final StatsListener listener;
+
+    private StatsListenerAdapterForStatsListener(StatsListener listener)
+    {
+      this.listener = listener;
+    }
+
+    @Override
+    public Response processStats(BatchedOperatorStats stats)
+    {
+      return listener.processStats(stats);
+    }
+
+    @Override
+    public Response processStats(BatchedOperatorStats stats, StatsListenerContext context)
+    {
+      return listener.processStats(stats);
+    }
+  }
+
+  private static StatsListenerWithContext getStatsListenerAdapter(StatsListener listener)
+  {
+    if (listener instanceof StatsListenerWithContext) {
+      return (StatsListenerWithContext)listener;
+    } else {
+      return new StatsListenerAdapterForStatsListener(listener);
+    }
   }
 
   /**
@@ -217,7 +278,7 @@ public class PhysicalPlan implements Serializable
     private final OperatorMeta logicalOperator;
     private List<PTOperator> partitions = new LinkedList<>();
     private final Map<LogicalPlan.OutputPortMeta, StreamMapping> outputStreams = Maps.newHashMap();
-    private List<StatsListener> statsHandlers;
+    private List<StatsListenerWithContext> statsHandlers;
 
     /**
      * Operators that form a parallel partition
@@ -768,7 +829,9 @@ public class PhysicalPlan implements Serializable
       if (m.statsHandlers == null) {
         m.statsHandlers = new ArrayList<>(statsListeners.size());
       }
-      m.statsHandlers.addAll(statsListeners);
+      for (StatsListener sl : statsListeners) {
+        m.statsHandlers.add(getStatsListenerAdapter(sl));
+      }
     }
 
     if (m.logicalOperator.getOperator() instanceof StatsListener) {
@@ -1523,11 +1586,22 @@ public class PhysicalPlan implements Serializable
    */
   public List<PTOperator> getOperators(OperatorMeta logicalOperator)
   {
+    /* During dynamic plan change, operators are added in logical plan first and then
+       physical plan is changed. There is a race, when REST api try to get information
+       about an operator which is not yet added in physical plan causes
+       NullPointerException here. null return value is handled at caller appropriately.
+     */
+    if (this.logicalToPTOperator.get(logicalOperator) == null) {
+      return null;
+    }
     return this.logicalToPTOperator.get(logicalOperator).partitions;
   }
 
   public Collection<PTOperator> getAllOperators(OperatorMeta logicalOperator)
   {
+    if (this.logicalToPTOperator.get(logicalOperator) == null) {
+      return null;
+    }
     return this.logicalToPTOperator.get(logicalOperator).getAllOperators();
   }
 
@@ -1535,7 +1609,10 @@ public class PhysicalPlan implements Serializable
   {
     List<PTOperator> operators = new ArrayList<>();
     for (OperatorMeta opMeta : dag.getLeafOperators()) {
-      operators.addAll(getAllOperators(opMeta));
+      Collection<PTOperator> allOpers = getAllOperators(opMeta);
+      if (allOpers != null) {
+        operators.addAll(allOpers);
+      }
     }
     return operators;
   }
@@ -1675,7 +1752,36 @@ public class PhysicalPlan implements Serializable
     } else {
       initPartitioning(pnodes, 0);
     }
+    /* Update stream mapping for upstream operator. In case of dynamic dag modification, if a
+     * new operator is connected to output port of existing operator we will need to fix the
+     * existing operators output ports.*/
+    updateUpstreamsOutputMappings(om, null);
     updateStreamMappings(pnodes);
+  }
+
+  /**
+   * Update stream mapping for upstream operator. In case of dynamic dag modification, if a
+   * new operator is connected to output port of existing operator we will need to fix the
+   * existing operators output ports.
+   * @param om
+   * @param ipm
+   */
+  private void updateUpstreamsOutputMappings(OperatorMeta om, InputPortMeta ipm)
+  {
+    for (Map.Entry<InputPortMeta, StreamMeta> entry : om.getInputStreams().entrySet()) {
+      if (ipm == null || entry.getKey() == ipm) {
+        for (Map.Entry<LogicalPlan.OutputPortMeta, StreamMeta> outputEntry : entry.getValue().getSource().getOperatorMeta().getOutputStreams().entrySet()) {
+          PMapping sourceOpers = this.logicalToPTOperator.get(outputEntry.getKey().getOperatorMeta());
+          if (sourceOpers != null && sourceOpers.partitions != null) {
+            for (PTOperator oper : sourceOpers.partitions) {
+              setupOutput(sourceOpers, oper, outputEntry); // idempotent
+              undeployOpers.add(oper);
+              deployOpers.add(oper);
+            }
+          }
+        }
+      }
+    }
   }
 
   /**
@@ -1793,8 +1899,8 @@ public class PhysicalPlan implements Serializable
 
   public void onStatusUpdate(PTOperator oper)
   {
-    for (StatsListener l : oper.statsListeners) {
-      final StatsListener.Response rsp = l.processStats(oper.stats);
+    for (StatsListenerWithContext l : oper.statsListeners) {
+      final StatsListener.Response rsp = l.processStats(oper.stats, statsListenerContext);
       if (rsp != null) {
         //LOG.debug("Response to processStats = {}", rsp.repartitionRequired);
         oper.loadIndicator = rsp.loadIndicator;
@@ -1898,5 +2004,65 @@ public class PhysicalPlan implements Serializable
       cmd.execute(operator,operatorId,windowId);
       return null;
     }
+  }
+
+  /**
+   * A interface object for the statsListener to access the DAG, it provides methods
+   * to get information about operators in the DAG.
+   */
+  private class StatsListenerContextImpl implements StatsListenerContext, Serializable
+  {
+
+    @Override
+    public String getOperatorName(int id)
+    {
+      PTOperator operator = getAllOperators().get(id);
+      if (operator != null) {
+        return operator.getName();
+      }
+      return null;
+    }
+
+    @Override
+    public DAG createDAG()
+    {
+      return new LogicalPlan();
+    }
+
+    @Override
+    public FutureTask<Object> submitDagChange(DAG dagChanges) throws IOException, ClassNotFoundException
+    {
+      if (getPendingDagChangeRequest() != null) {
+        return null;
+      }
+
+      /**
+       * do a logical plan modification/validation checks before actual plan is submitted
+       * */
+      LogicalPlan lp = (LogicalPlan)SerializationUtils.clone(getLogicalPlan());
+      PlanModifier pm = new PlanModifier(lp);
+      pm.applyDagChangeSet(dagChanges);
+      lp.validate();
+
+      synchronized (PhysicalPlan.this) {
+
+        if (getPendingDagChangeRequest() != null) {
+          return null;
+        }
+
+        setPendingDagChangeRequest(dagChanges);
+        return ctx.addDagChangeRequests(dagChanges);
+      }
+    }
+  }
+
+  public DAG getPendingDagChangeRequest()
+  {
+    return pendingDagChangeRequest;
+  }
+
+  public void setPendingDagChangeRequest(DAG pendingDagChangeRequest)
+  {
+    this.pendingDagChangeRequest = pendingDagChangeRequest;
   }
 }

--- a/engine/src/test/java/com/datatorrent/stram/LogicalPlanModificationTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/LogicalPlanModificationTest.java
@@ -238,8 +238,8 @@ public class LogicalPlanModificationTest
     Assert.assertTrue("operators " + dag.getAllOperators(), dag.getAllOperators().containsAll(Sets.newHashSet(o1Meta, o3Meta)));
 
     try {
-      plan.getOperators(o2Meta);
-      Assert.fail("removed from physical plan: " + o2Meta);
+      List<PTOperator> operators = plan.getOperators(o2Meta);
+      Assert.assertNull("removed from physical plan " + o2Meta, operators);
     } catch (Exception e) {
       // all good
     }

--- a/engine/src/test/java/com/datatorrent/stram/PartitioningTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/PartitioningTest.java
@@ -48,6 +48,7 @@ import com.datatorrent.api.DefaultPartition;
 import com.datatorrent.api.InputOperator;
 import com.datatorrent.api.Partitioner;
 import com.datatorrent.api.StatsListener;
+import com.datatorrent.api.StatsListener.StatsListenerWithContext;
 import com.datatorrent.api.annotation.OutputPortFieldAnnotation;
 import com.datatorrent.common.partitioner.StatelessPartitioner;
 import com.datatorrent.common.util.AsyncFSStorageAgent;
@@ -209,13 +210,19 @@ public class PartitioningTest
     Assert.assertEquals("merged tuples " + pmerged, Sets.newHashSet(testData[0]), Sets.newHashSet(tuples));
   }
 
-  public static class PartitionLoadWatch implements StatsListener, java.io.Serializable
+  public static class PartitionLoadWatch implements StatsListenerWithContext, java.io.Serializable
   {
     private static final long serialVersionUID = 1L;
     private static final ThreadLocal<Map<Integer, Integer>> loadIndicators = new ThreadLocal<>();
 
     @Override
-    public Response processStats(BatchedOperatorStats status)
+    public Response processStats(BatchedOperatorStats stats)
+    {
+      return processStats(stats, null);
+    }
+
+    @Override
+    public Response processStats(BatchedOperatorStats status, StatsListenerContext context)
     {
       Response hbr = null;
       Map<Integer, Integer> m = loadIndicators.get();

--- a/engine/src/test/java/com/datatorrent/stram/engine/InputOperatorTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/engine/InputOperatorTest.java
@@ -55,6 +55,7 @@ public class InputOperatorTest
     public final transient DefaultOutputPort<Integer> odd = new DefaultOutputPort<Integer>();
     private final transient CircularBuffer<Integer> evenBuffer = new CircularBuffer<Integer>(1024);
     private final transient CircularBuffer<Integer> oddBuffer = new CircularBuffer<Integer>(1024);
+
     private volatile Thread dataGeneratorThread;
 
     @Override

--- a/engine/src/test/java/com/datatorrent/stram/plan/TestPlanContext.java
+++ b/engine/src/test/java/com/datatorrent/stram/plan/TestPlanContext.java
@@ -21,17 +21,20 @@ package com.datatorrent.stram.plan;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.FutureTask;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
+import com.datatorrent.api.DAG;
 import com.datatorrent.api.Stats.OperatorStats;
 import com.datatorrent.api.StatsListener;
 import com.datatorrent.api.StorageAgent;
@@ -43,7 +46,7 @@ import com.datatorrent.stram.plan.physical.PTContainer;
 import com.datatorrent.stram.plan.physical.PTOperator;
 import com.datatorrent.stram.plan.physical.PhysicalPlan.PlanContext;
 
-public class TestPlanContext implements PlanContext, StorageAgent
+public class TestPlanContext implements PlanContext, StorageAgent, Serializable
 {
   public List<Runnable> events = new ArrayList<Runnable>();
   public Collection<PTOperator> undeploy;
@@ -187,6 +190,12 @@ public class TestPlanContext implements PlanContext, StorageAgent
     {
       return null;
     }
+
   }
 
+  @Override
+  public FutureTask<Object> addDagChangeRequests(DAG dag)
+  {
+    return null;
+  }
 }

--- a/engine/src/test/java/com/datatorrent/stram/plan/physical/PhysicalPlanTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/plan/physical/PhysicalPlanTest.java
@@ -55,13 +55,16 @@ import com.datatorrent.api.Partitioner;
 import com.datatorrent.api.Partitioner.Partition;
 import com.datatorrent.api.Partitioner.PartitionKeys;
 import com.datatorrent.api.StatsListener;
+import com.datatorrent.api.StatsListener.StatsListenerWithContext;
 import com.datatorrent.api.StreamCodec;
 import com.datatorrent.api.annotation.InputPortFieldAnnotation;
 import com.datatorrent.common.partitioner.StatelessPartitioner;
+import com.datatorrent.common.util.BaseOperator;
 import com.datatorrent.stram.PartitioningTest;
 import com.datatorrent.stram.PartitioningTest.TestInputOperator;
 import com.datatorrent.stram.api.Checkpoint;
 import com.datatorrent.stram.codec.DefaultStatefulStreamCodec;
+import com.datatorrent.stram.engine.GenericNodeTest;
 import com.datatorrent.stram.engine.GenericTestOperator;
 import com.datatorrent.stram.engine.TestGeneratorInputOperator;
 import com.datatorrent.stram.plan.TestPlanContext;
@@ -79,7 +82,7 @@ public class PhysicalPlanTest
    * Stats listener for throughput based partitioning.
    * Used when thresholds are configured on operator through attributes.
    */
-  public static class PartitionLoadWatch implements StatsListener, java.io.Serializable
+  public static class PartitionLoadWatch implements StatsListenerWithContext, java.io.Serializable
   {
     private static final Logger logger = LoggerFactory.getLogger(PartitionLoadWatch.class);
     private static final long serialVersionUID = 201312231633L;
@@ -110,7 +113,13 @@ public class PhysicalPlanTest
     }
 
     @Override
-    public Response processStats(BatchedOperatorStats status)
+    public Response processStats(BatchedOperatorStats stats)
+    {
+      return processStats(stats, null);
+    }
+
+    @Override
+    public Response processStats(BatchedOperatorStats status, StatsListenerContext context)
     {
 
       long tps = status.getTuplesProcessedPSMA();
@@ -1625,7 +1634,6 @@ public class PhysicalPlanTest
 
     LogicalPlan dag = new LogicalPlan();
 
-    //TestGeneratorInputOperator o1 = dag.addOperator("o1", TestGeneratorInputOperator.class);
     PartitioningTestOperator o1 = dag.addOperator("o1", PartitioningTestOperator.class);
     o1.partitionKeys = new Integer[] {0,1,2,3};
     o1.setPartitionCount(o1.partitionKeys.length);
@@ -1727,7 +1735,6 @@ public class PhysicalPlanTest
 
     LogicalPlan dag = new LogicalPlan();
 
-    //TestGeneratorInputOperator o1 = dag.addOperator("o1", TestGeneratorInputOperator.class);
     PartitioningTestOperator o1 = dag.addOperator("o1", PartitioningTestOperator.class);
     o1.partitionKeys = new Integer[]{0, 1, 2, 3};
     o1.setPartitionCount(3);
@@ -2245,5 +2252,127 @@ public class PhysicalPlanTest
     dag.addStream("o2.outport1", o2.outport1, o3.inport1);
     PhysicalPlan plan = new PhysicalPlan(dag, new TestPlanContext());
     Assert.assertEquals("number of containers", 7, plan.getContainers().size());
+  }
+
+  static class NoOpStatsListener implements StatsListener
+  {
+    @Override
+    public Response processStats(BatchedOperatorStats stats)
+    {
+      return null;
+    }
+  }
+
+  static class NoOpStatsListenerWithContext implements StatsListenerWithContext
+  {
+    @Override
+    public Response processStats(BatchedOperatorStats stats)
+    {
+      return null;
+    }
+
+    @Override
+    public Response processStats(BatchedOperatorStats stats, StatsListenerContext context)
+    {
+      return null;
+    }
+  }
+
+  static class StatsListenerOperatorOld extends BaseOperator implements StatsListener
+  {
+    @Override
+    public Response processStats(BatchedOperatorStats stats)
+    {
+      return null;
+    }
+  }
+
+  static class StatsListenerOperator extends GenericNodeTest.GenericOperator implements StatsListenerWithContext
+  {
+    @Override
+    public Response processStats(BatchedOperatorStats stats, StatsListenerContext context)
+    {
+      return null;
+    }
+
+    @Override
+    public Response processStats(BatchedOperatorStats stats)
+    {
+      return null;
+    }
+  }
+
+  /**
+   * Test that internally all stats listeners are handled through StatsListenerWithContext.
+   * Following cases are tested
+   *
+   * Operator implementing StatsListener
+   * Operator implementing StatsListenerWithContext
+   * Operator with STATS_LISTENERS attribute set to StatsListener
+   * Operator with STATS_LISTENERS attribute set to StatsListenerWithContext
+   */
+  @Test
+  public void testStatsListenerContextWrappers()
+  {
+    LogicalPlan dag = new LogicalPlan();
+    dag.setAttribute(OperatorContext.STORAGE_AGENT, new StramTestSupport.MemoryStorageAgent());
+
+    StatsListenerOperator o1 = dag.addOperator("o1", new StatsListenerOperator());
+    GenericTestOperator o2 = dag.addOperator("o2", new GenericTestOperator());
+    dag.setAttribute(o2, OperatorContext.STATS_LISTENERS,
+        Lists.<StatsListener>newArrayList(new NoOpStatsListener()));
+
+    GenericTestOperator o3 = dag.addOperator("o3", new GenericTestOperator());
+    dag.setAttribute(o3, OperatorContext.STATS_LISTENERS,
+        Lists.<StatsListener>newArrayList(new NoOpStatsListenerWithContext()));
+
+    StatsListenerOperatorOld o4 = dag.addOperator("o4", new StatsListenerOperatorOld());
+
+    PhysicalPlan plan = new PhysicalPlan(dag, new TestPlanContext());
+
+    PTOperator p1 = plan.getOperators(dag.getMeta(o1)).get(0);
+    StatsListener l = p1.statsListeners.get(0);
+    Assert.assertTrue("Operator stats listener is wrapped ", l instanceof StatsListenerWithContext);
+
+    PTOperator p2 = plan.getOperators(dag.getMeta(o2)).get(0);
+    l = p1.statsListeners.get(0);
+    Assert.assertTrue("Operator stats listener is wrapped ", l instanceof StatsListenerWithContext);
+
+    PTOperator p3 = plan.getOperators(dag.getMeta(o3)).get(0);
+    l = p1.statsListeners.get(0);
+    Assert.assertTrue("Operator stats listener is wrapped ", l instanceof StatsListenerWithContext);
+
+    PTOperator p4 = plan.getOperators(dag.getMeta(o4)).get(0);
+    l = p1.statsListeners.get(0);
+    Assert.assertTrue("Operator stats listener is wrapped ", l instanceof StatsListenerWithContext);
+  }
+
+  @Test
+  public void addNewDisconnectedLogicalPlan()
+  {
+    LogicalPlan dag = new LogicalPlan();
+    GenericTestOperator o1 = dag.addOperator("o1", new GenericTestOperator());
+    dag.setAttribute(Context.OperatorContext.STORAGE_AGENT, new TestPlanContext());
+
+    TestPlanContext ctx = new TestPlanContext();
+    PhysicalPlan plan = new PhysicalPlan(dag, ctx);
+    Assert.assertEquals("number of operators in physical plan", 1, plan.getAllOperators().size());
+    Assert.assertEquals("new operators to deploy stage 1 ", 1, ctx.deploy.size());
+
+    LogicalPlan newDag = new LogicalPlan();
+    GenericTestOperator o2 = newDag.addOperator("o2", new GenericTestOperator());
+    GenericTestOperator o3 = newDag.addOperator("o3", new GenericTestOperator());
+    GenericTestOperator o4 = newDag.addOperator("o4", new GenericTestOperator());
+    GenericTestOperator o5 = newDag.addOperator("o5", new GenericTestOperator());
+
+    newDag.addStream("s1", o2.outport1, o3.inport1);
+    newDag.addStream("s2", o3.outport1, o4.inport1);
+    newDag.addStream("s3", o4.outport1, o5.inport1);
+
+    PlanModifier pm = new PlanModifier(plan);
+    pm.applyDagChangeSet(newDag);
+
+    Assert.assertEquals("new operators in the Dag is ", 5, plan.getAllOperators().size());
+    Assert.assertEquals("number of deploy operators ", 4, ctx.deploy.size());
   }
 }


### PR DESCRIPTION
Pull request for dynamic dag modification through stats listener.  It provides following
functionality
- StatsListener can access the opearator name for easily detecting which opearator stats are being processed.
- StatsListener can create a instance of object through which it can submit dag modifications to the engine.
- StatsListener can return dag changes as a response to engine.
- PlanModifier is modified to take a DAG and apply it on the existing running DAG and deploy the changes.

The following functionality is not working yet.
- The new opearator does not start from the correct windowId (https://issues.apache.org/jira/browse/APEXCORE-532)
- Relanched application failed to start when it was killed after dynamic dag modification.
- There is no support for resuming operator from previous state when they were removed. This could be achived through
  readig state through external storage on setup.
- persist operator support is not present for newly added streams.
- Not all parts are covered through tests.

The demo application using the feature is available at
https://github.com/tushargosavi/apex-dynamic-scheduling

There are two variations of WordCount application. The first variation detects the presence of
new files start a disconnected DAG to process the data.
(https://github.com/tushargosavi/apex-dynamic-scheduling/blob/master/src/main/java/com/datatorrent/wordcount/WordCountApp.java)

The second application (https://github.com/tushargosavi/apex-dynamic-scheduling/blob/master/src/main/java/com/datatorrent/wordcount/ExtendApp.java),
initially only one reader operator is running in the DAG, and provides pendingFiles as auto-metric to stat listener.
On detecting pending files it attaches splitter counter and output operator to the read operator. Once files are processed the splitter, counter and
output operators are removed and added back again if new data files are added into the directory.
