### PR TITLE
[APEXCORE-528] Fix OutputPort Default Optional Behavior 

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlan.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlan.java
@@ -1745,7 +1745,6 @@ public class LogicalPlan implements Serializable, DAG
         }
       }
 
-      boolean allPortsOptional = true;
       for (OutputPortMeta pm: portMapping.outPortMap.values()) {
         checkAttributeValueSerializable(pm.getAttributes(), n.getName() + "." + pm.getPortName());
         if (!n.outputStreams.containsKey(pm)) {
@@ -1765,10 +1764,6 @@ public class LogicalPlan implements Serializable, DAG
             }
           }
         }
-        allPortsOptional &= (pm.portAnnotation != null && pm.portAnnotation.optional());
-      }
-      if (!allPortsOptional && n.outputStreams.isEmpty()) {
-        throw new ValidationException("At least one output port must be connected: " + n.name);
       }
     }
 

--- a/engine/src/test/java/com/datatorrent/stram/plan/logical/LogicalPlanTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/plan/logical/LogicalPlanTest.java
@@ -641,7 +641,6 @@ public class LogicalPlanTest
 
   private class TestAnnotationsOperator2 extends BaseOperator implements InputOperator
   {
-    // multiple ports w/o annotation, one of them must be connected
     public final transient DefaultOutputPort<Object> outport1 = new DefaultOutputPort<Object>();
 
     @Override
@@ -653,7 +652,6 @@ public class LogicalPlanTest
 
   private class TestAnnotationsOperator3 extends BaseOperator implements InputOperator
   {
-    // multiple ports w/o annotation, one of them must be connected
     @OutputPortFieldAnnotation(optional = true)
     public final transient DefaultOutputPort<Object> outport1 = new DefaultOutputPort<Object>();
     @OutputPortFieldAnnotation(optional = true)
@@ -687,12 +685,8 @@ public class LogicalPlanTest
 
     TestAnnotationsOperator2 ta2 = dag.addOperator("multiOutputPorts1", new TestAnnotationsOperator2());
 
-    try {
-      dag.validate();
-      Assert.fail("should raise: At least one output port must be connected");
-    } catch (ValidationException e) {
-      Assert.assertEquals("", "At least one output port must be connected: multiOutputPorts1", e.getMessage());
-    }
+    dag.validate();
+
     TestOutputOperator o3 = dag.addOperator("o3", new TestOutputOperator());
     dag.addStream("s2", ta2.outport1, o3.inport);
 


### PR DESCRIPTION
This PR removes the validation logic that requires output ports to be connected if not explicitly annotated as optional. This change complies with the behavior defined by the optional annotation as it states they should be optional by default.

