### PR TITLE
APEXCORE-575 Improve application restart time.

### DIFF
--- a/common/src/main/java/com/datatorrent/common/util/FSStorageAgent.java
+++ b/common/src/main/java/com/datatorrent/common/util/FSStorageAgent.java
@@ -18,6 +18,7 @@
  */
 package com.datatorrent.common.util;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectStreamException;
@@ -153,6 +154,16 @@ public class FSStorageAgent implements StorageAgent, Serializable
   public long[] getWindowIds(int operatorId) throws IOException
   {
     Path lPath = new Path(path + Path.SEPARATOR + String.valueOf(operatorId));
+    try {
+      FileStatus status = fileContext.getFileStatus(lPath);
+      if (!status.isDirectory()) {
+        throw new IOException("Checkpoint location is not a directory ");
+      }
+    } catch (FileNotFoundException ex) {
+      // During initialization this directory may not exists.
+      // return an empty array.
+      return new long[0];
+    }
 
     RemoteIterator<FileStatus> fileStatusRemoteIterator = fileContext.listStatus(lPath);
     if (!fileStatusRemoteIterator.hasNext()) {

--- a/common/src/main/java/org/apache/apex/common/util/AsyncStorageAgent.java
+++ b/common/src/main/java/org/apache/apex/common/util/AsyncStorageAgent.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.apex.common.util;
+
+import java.io.IOException;
+
+import org.apache.hadoop.classification.InterfaceStability;
+
+import com.datatorrent.api.StorageAgent;
+
+/**
+ * Storage agent which can take checkpoints asynchronously.
+ * An AsyncStorageAgent enables quick checkpoints by taking local snapshot of an operator
+ * and unblocking the operator to process more data, while storage engine is pushing local snapshot to
+ * the distributed or globally accessible location for recovery.
+ */
+@InterfaceStability.Evolving
+public interface AsyncStorageAgent extends StorageAgent
+{
+  /**
+   * Make checkpoint for given windowID final. i.e after this method returns,
+   * the checkpoint is accessible for recovery.
+   *
+   * @param operatorId
+   * @param windowId
+   * @throws IOException
+   */
+  public void finalize(int operatorId, long windowId) throws IOException;
+
+  /**
+   * Check if StorageAgent is configured to take synchronous checkpoints.
+   *
+   * @return true if StorageAgent is configured to take synchronous checkpoints.
+   * @return false otherwise.
+   */
+  public boolean isSyncCheckpoint();
+
+}

--- a/common/src/main/java/org/apache/apex/common/util/CascadeStorageAgent.java
+++ b/common/src/main/java/org/apache/apex/common/util/CascadeStorageAgent.java
@@ -1,0 +1,202 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.apex.common.util;
+
+import java.io.IOException;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Maps;
+
+import com.datatorrent.api.StorageAgent;
+
+/**
+ * A StorageAgent which chains two StorageAgent. It use the current storage-agent to store
+ * the checkpoint, and use the parent agent to read old checkpoints. For application having
+ * large number of physical operators, the size and number of files to be copied could be
+ * large impacting application restart time. This storage-agent is used during application
+ * restart to avoiding copying checkpoints from old application directory to improve application
+ * restart time.
+ */
+public class CascadeStorageAgent implements StorageAgent, AsyncStorageAgent, Serializable
+{
+  private static final Logger logger = LoggerFactory.getLogger(CascadeStorageAgent.class);
+  private final StorageAgent parent;
+  private final StorageAgent current;
+  private final transient Map<Integer, long[]> oldOperatorToWindowIdsMap;
+
+  public CascadeStorageAgent(StorageAgent parent, StorageAgent current)
+  {
+    this.parent = parent;
+    this.current = current;
+    oldOperatorToWindowIdsMap = Maps.newConcurrentMap();
+  }
+
+  /**
+   * does the checkpoint belong to parent
+   */
+  private boolean isCheckpointFromParent(int operatorId, long wid) throws IOException
+  {
+    long[] wids = getParentWindowIds(operatorId);
+    if (wids.length != 0) {
+      return (wid <= wids[wids.length - 1]);
+    }
+    return false;
+  }
+
+  /**
+   * Return window-id of checkpoints available in old storage agent. This function
+   * will call getWindowIds of old storage agent only once for the fist time, and
+   * return cached data for next calls for same operator.
+   *
+   * @param operatorId
+   * @return
+   * @throws IOException
+   */
+  private long[] getParentWindowIds(int operatorId) throws IOException
+  {
+    long[] oldWindowIds = oldOperatorToWindowIdsMap.get(operatorId);
+    if (oldWindowIds == null) {
+      oldWindowIds = parent.getWindowIds(operatorId);
+      if (oldWindowIds == null) {
+        oldWindowIds = new long[0];
+      }
+      Arrays.sort(oldWindowIds);
+      oldOperatorToWindowIdsMap.put(operatorId, oldWindowIds);
+      logger.debug("CascadeStorageAgent window ids from old storage agent op {} wids {}", operatorId, Arrays.toString(oldWindowIds));
+    }
+    return oldWindowIds;
+  }
+
+  /**
+   * Save object in current storage agent. This should not modify old storage agent
+   * in any way.
+   *
+   * @param object - The operator whose state needs to be saved.
+   * @param operatorId - Identifier of the operator.
+   * @param windowId - Identifier for the specific state of the operator.
+   * @throws IOException
+   */
+  @Override
+  public void save(Object object, int operatorId, long windowId) throws IOException
+  {
+    current.save(object, operatorId, windowId);
+  }
+
+  /**
+   * Delete old checkpoints from the storage agent.
+   *
+   * The checkpoints are deleted from current directory if it is present in current
+   * storage agent. and cached state for old storage agent is removed.
+   *
+   * @param operatorId
+   * @param windowId
+   * @throws IOException
+   */
+  @Override
+  public void delete(int operatorId, long windowId) throws IOException
+  {
+    if (!isCheckpointFromParent(operatorId, windowId)) {
+      current.delete(operatorId, windowId);
+    }
+  }
+
+  /**
+   * Load checkpoint from storage agents. Do a basic comparision of windowIds
+   * to check the storage agent which has the checkpoint.
+   *
+   * @param operatorId Id for which the object was previously saved
+   * @param windowId WindowId for which the object was previously saved
+   * @return
+   * @throws IOException
+   */
+  @Override
+  public Object load(int operatorId, long windowId) throws IOException
+  {
+    long[] oldWindowIds = getParentWindowIds(operatorId);
+    if (oldWindowIds.length >= 1 && windowId <= oldWindowIds[oldWindowIds.length - 1]) {
+      return parent.load(operatorId, windowId);
+    }
+    return current.load(operatorId, windowId);
+  }
+
+  @Override
+  public long[] getWindowIds(int operatorId) throws IOException
+  {
+    long[] currentIds = current.getWindowIds(operatorId);
+    long[] oldWindowIds = getParentWindowIds(operatorId);
+    return merge(currentIds, oldWindowIds);
+  }
+
+  private static final long[] EMPTY_LONG_ARRAY = new long[0];
+  private long[] merge(long[] currentIds, long[] oldWindowIds)
+  {
+    if (currentIds == null && oldWindowIds == null) {
+      return EMPTY_LONG_ARRAY;
+    }
+    if (currentIds == null) {
+      return oldWindowIds;
+    }
+    if (oldWindowIds == null) {
+      return currentIds;
+    }
+    long[] mergedArray = new long[currentIds.length + oldWindowIds.length];
+    System.arraycopy(currentIds, 0, mergedArray, 0, currentIds.length);
+    System.arraycopy(oldWindowIds, 0, mergedArray, currentIds.length, oldWindowIds.length);
+    Arrays.sort(mergedArray);
+    return mergedArray;
+  }
+
+  @Override
+  public void finalize(int operatorId, long windowId) throws IOException
+  {
+    if (current instanceof AsyncStorageAgent) {
+      ((AsyncStorageAgent)current).finalize(operatorId, windowId);
+    }
+  }
+
+  @Override
+  public boolean isSyncCheckpoint()
+  {
+    if (parent instanceof AsyncStorageAgent) {
+      return ((AsyncStorageAgent)parent).isSyncCheckpoint();
+    }
+    return true;
+  }
+
+  public Object readResolve() throws ObjectStreamException
+  {
+    return new CascadeStorageAgent(parent, current);
+  }
+
+  public StorageAgent getCurrentStorageAgent()
+  {
+    return current;
+  }
+
+  public StorageAgent getParentStorageAgent()
+  {
+    return parent;
+  }
+}

--- a/common/src/test/java/com/datatorrent/common/util/CascadeStorageAgentTest.java
+++ b/common/src/test/java/com/datatorrent/common/util/CascadeStorageAgentTest.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.datatorrent.common.util;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+import org.apache.apex.common.util.CascadeStorageAgent;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.fs.FileContext;
+import org.apache.hadoop.fs.Path;
+
+import com.datatorrent.api.Attribute;
+import com.datatorrent.api.DAG;
+
+public class CascadeStorageAgentTest
+{
+
+  static class TestMeta extends TestWatcher
+  {
+    String applicationPath;
+
+    @Override
+    protected void starting(Description description)
+    {
+      super.starting(description);
+      applicationPath = "target/" + description.getClassName() + "/" + description.getMethodName();
+      try {
+        FileUtils.forceMkdir(new File("target/" + description.getClassName()));
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      Attribute.AttributeMap.DefaultAttributeMap attributes = new Attribute.AttributeMap.DefaultAttributeMap();
+      attributes.put(DAG.APPLICATION_PATH, applicationPath);
+    }
+
+    @Override
+    protected void finished(Description description)
+    {
+      try {
+        FileUtils.deleteDirectory(new File("target/" + description.getClassName()));
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  @Rule
+  public TestMeta testMeta = new TestMeta();
+
+  @Test
+  public void testSingleIndirection() throws IOException
+  {
+    String oldAppPath = testMeta.applicationPath;
+    FSStorageAgent storageAgent = new FSStorageAgent(oldAppPath, null);
+    storageAgent.save("1", 1, 1);
+    storageAgent.save("2", 1, 2);
+    storageAgent.save("3", 2, 1);
+
+    String newAppPath = oldAppPath + ".new";
+    CascadeStorageAgent cascade = new CascadeStorageAgent(storageAgent, new FSStorageAgent(newAppPath, null));
+    long[] operatorIds = cascade.getWindowIds(1);
+    Assert.assertArrayEquals("Returned window ids ", operatorIds, new long[]{1L, 2L});
+
+    operatorIds = cascade.getWindowIds(2);
+    Assert.assertArrayEquals("Returned window ids ", operatorIds, new long[]{1L});
+
+    /* save should happen to new location */
+    cascade.save("4", 1, 4);
+    FileContext fileContext = FileContext.getFileContext();
+    Assert.assertFalse("operator 1 window 4 file does not exists in old directory", fileContext.util().exists(new Path(oldAppPath + "/" + 1 + "/" + 4)));
+    Assert.assertTrue("operator 1 window 4 file exists in new directory", fileContext.util().exists(new Path(newAppPath + "/" + 1 + "/" + 4)));
+
+    // check for delete,
+    // delete for old checkpoint should be ignored
+    cascade.save("5", 1, 5);
+    cascade.delete(1, 2L);
+    Assert.assertTrue("operator 1 window 2 file exists in old directory", fileContext.util().exists(new Path(oldAppPath + "/" + 1 + "/" + 2)));
+    cascade.delete(1, 4L);
+    Assert.assertFalse("operator 1 window 4 file does not exists in old directory", fileContext.util().exists(new Path(newAppPath + "/" + 1 + "/" + 4)));
+
+    /* chaining of storage agent */
+    String latestAppPath = oldAppPath + ".latest";
+    cascade = new CascadeStorageAgent(storageAgent, new FSStorageAgent(newAppPath, null));
+    CascadeStorageAgent latest = new CascadeStorageAgent(cascade, new FSStorageAgent(latestAppPath, null));
+    operatorIds = latest.getWindowIds(1);
+    Assert.assertArrayEquals("Window ids ", operatorIds, new long[] {1,2,5});
+
+    latest.save("6", 1, 6);
+    Assert.assertFalse("operator 1 window 6 file does not exists in old directory", fileContext.util().exists(new Path(oldAppPath + "/" + 1 + "/" + 6)));
+    Assert.assertFalse("operator 1 window 6 file does not exists in old directory", fileContext.util().exists(new Path(newAppPath + "/" + 1 + "/" + 6)));
+    Assert.assertTrue("operator 1 window 6 file exists in new directory", fileContext.util().exists(new Path(latestAppPath + "/" + 1 + "/" + 6)));
+  }
+}


### PR DESCRIPTION
I have implemented a new storage agent (CascadeStorageAgent) which maintains two storage agents one for old checkpoint directory and one for new checkpoint directory, using this storage agent we could direct read on old directory during initial start, and write to new checkpoint directory. With this we could avoid copy of checkpoints from old directory to new directory. with 2 GB state application restart was brought down to few seconds from 2 minutes.

Other changes are
- Add log message to print time taken to copy the initial state.
- Do not copy stats and events directory as they are overwritten anyway in the new application.
- Use new storage agent to avoid copying checkpoints directory.
