### PR TITLE
APEXCORE-592 Returning description field in defaultProperties during apex cli call get-app-package-info

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/cli/ApexCli.java
+++ b/engine/src/main/java/com/datatorrent/stram/cli/ApexCli.java
@@ -101,6 +101,7 @@ import com.datatorrent.stram.client.AppPackage.AppInfo;
 import com.datatorrent.stram.client.ConfigPackage;
 import com.datatorrent.stram.client.DTConfiguration;
 import com.datatorrent.stram.client.DTConfiguration.Scope;
+import com.datatorrent.stram.client.DTConfiguration.ValueEntry;
 import com.datatorrent.stram.client.RecordingsAgent;
 import com.datatorrent.stram.client.RecordingsAgent.RecordingInfo;
 import com.datatorrent.stram.client.StramAgent;
@@ -3702,11 +3703,11 @@ public class ApexCli
         break;
       }
     }
-    Map<String, String> defaultProperties = selectedApp == null ? ap.getDefaultProperties() : selectedApp.defaultProperties;
+    Map<String, ValueEntry> defaultProperties = selectedApp == null ? ap.getDefaultProperties() : selectedApp.defaultProperties;
     Set<String> requiredProperties = new TreeSet<>(selectedApp == null ? ap.getRequiredProperties() : selectedApp.requiredProperties);
 
-    for (Map.Entry<String, String> entry : defaultProperties.entrySet()) {
-      launchProperties.set(entry.getKey(), entry.getValue(), Scope.TRANSIENT, null);
+    for (Map.Entry<String, ValueEntry> entry : defaultProperties.entrySet()) {
+      launchProperties.set(entry.getKey(), entry.getValue().value, Scope.TRANSIENT, entry.getValue().description);
       requiredProperties.remove(entry.getKey());
     }
 

--- a/engine/src/main/java/com/datatorrent/stram/client/AppPackage.java
+++ b/engine/src/main/java/com/datatorrent/stram/client/AppPackage.java
@@ -42,6 +42,7 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 
+import com.datatorrent.stram.client.DTConfiguration.ValueEntry;
 import com.datatorrent.stram.client.StramAppLauncher.AppFactory;
 import com.datatorrent.stram.plan.logical.LogicalPlan;
 
@@ -81,7 +82,7 @@ public class AppPackage extends JarFile
   private final List<String> appPropertiesFiles = new ArrayList<>();
 
   private final Set<String> requiredProperties = new TreeSet<>();
-  private final Map<String, String> defaultProperties = new TreeMap<>();
+  private final Map<String, ValueEntry> defaultProperties = new TreeMap<>();
   private final Set<String> configs = new TreeSet<>();
 
   private final File resourcesDirectory;
@@ -98,7 +99,7 @@ public class AppPackage extends JarFile
     public String errorStackTrace;
 
     public Set<String> requiredProperties = new TreeSet<>();
-    public Map<String, String> defaultProperties = new TreeMap<>();
+    public Map<String, ValueEntry> defaultProperties = new TreeMap<>();
 
     public AppInfo(String name, String file, String type)
     {
@@ -317,7 +318,7 @@ public class AppPackage extends JarFile
     return Collections.unmodifiableSet(requiredProperties);
   }
 
-  public Map<String, String> getDefaultProperties()
+  public Map<String, ValueEntry> getDefaultProperties()
   {
     return Collections.unmodifiableMap(defaultProperties);
   }
@@ -426,10 +427,11 @@ public class AppPackage extends JarFile
     DTConfiguration config = new DTConfiguration();
     try {
       config.loadFile(file);
-      for (Map.Entry<String, String> entry : config) {
+      for (Map.Entry<String, ValueEntry> entry : config.getMap().entrySet()) {
         String key = entry.getKey();
-        String value = entry.getValue();
-        if (value == null) {
+        ValueEntry valueEntry = entry.getValue();
+        LOG.info("Properties: {} {} {}", key, valueEntry.value, valueEntry.description);
+        if (valueEntry.value == null) {
           if (app == null) {
             requiredProperties.add(key);
           } else {
@@ -437,10 +439,10 @@ public class AppPackage extends JarFile
           }
         } else {
           if (app == null) {
-            defaultProperties.put(key, value);
+            defaultProperties.put(key, valueEntry);
           } else {
             app.requiredProperties.remove(key);
-            app.defaultProperties.put(key, value);
+            app.defaultProperties.put(key, valueEntry);
           }
         }
       }

--- a/engine/src/main/java/com/datatorrent/stram/client/DTConfiguration.java
+++ b/engine/src/main/java/com/datatorrent/stram/client/DTConfiguration.java
@@ -99,6 +99,11 @@ public class DTConfiguration implements Iterable<Map.Entry<String, String>>
     return result.entrySet().iterator();
   }
 
+  public Map<String, ValueEntry> getMap()
+  {
+    return map;
+  }
+
   public void writeToFile(File file, Scope scope, String comment) throws IOException
   {
     SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");

--- a/engine/src/test/java/com/datatorrent/stram/client/AppPackageTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/client/AppPackageTest.java
@@ -125,7 +125,7 @@ public class AppPackageTest
   }
 
   @Test
-  public void testAppLevelRequiredProperties()
+  public void testAppLevelRequiredAndDefaultProperties()
   {
     List<AppPackage.AppInfo> applications = ap.getApplications();
     for (AppPackage.AppInfo app : applications) {
@@ -133,7 +133,8 @@ public class AppPackageTest
         String[] rp = app.requiredProperties.toArray(new String[]{});
         Assert.assertEquals("dt.test.required.2", rp[0]);
         Assert.assertEquals("dt.test.required.3", rp[1]);
-        Assert.assertEquals("app-default-for-required-1", app.defaultProperties.get("dt.test.required.1"));
+        Assert.assertEquals("app-default-for-required-1", app.defaultProperties.get("dt.test.required.1").value);
+        Assert.assertEquals("app-default-for-required-1-description", app.defaultProperties.get("dt.test.required.1").description);
         return;
       }
     }

--- a/engine/src/test/resources/testAppPackage/mydtapp/src/main/resources/META-INF/properties-MyFirstApplication.xml
+++ b/engine/src/test/resources/testAppPackage/mydtapp/src/main/resources/META-INF/properties-MyFirstApplication.xml
@@ -43,6 +43,7 @@
   <property>
     <name>dt.test.required.1</name>
     <value>app-default-for-required-1</value>
+    <description>app-default-for-required-1-description</description>
   </property>
   <property>
     <name>dt.test.required.3</name>


### PR DESCRIPTION
@bhupeshchawda @tushargosavi Kindly review the changes.

Value returned Earlier
"dt.application.CouchBaseAppOutput.operator.couchbaseOuput.port.*.QUEUE_CAPACITY": "32768"

Value returned Now
"dt.application.CouchBaseAppOutput.operator.couchbaseOuput.port.*.QUEUE_CAPACITY": {
          "value": "32768",
          "isFinal": false,
          "scope": "TRANSIENT",
          "description": "Specify queue capacity for all output ports"
        },
