### PR TITLE
*Review only* APEXCORE-259 Directly write to DataList

### DIFF
--- a/bufferserver/src/main/java/com/datatorrent/bufferserver/internal/DataList.java
+++ b/bufferserver/src/main/java/com/datatorrent/bufferserver/internal/DataList.java
@@ -99,12 +99,8 @@ public class DataList
     return blockSize;
   }
 
-  public void rewind(final int baseSeconds, final int windowId) throws IOException
+  public void rewind(final long longWindowId) throws IOException
   {
-    final long longWindowId = (long)baseSeconds << 32 | windowId;
-    logger.debug("Rewinding {} from window ID {} to window ID {}", this, Codec.getStringWindowId(last.ending_window),
-        Codec.getStringWindowId(longWindowId));
-
     int numberOfInMemBlockRewound = 0;
     synchronized (this) {
       for (Block temp = first; temp != null; temp = temp.next) {
@@ -149,6 +145,14 @@ public class DataList
     logger.debug("Discarded {} in memory blocks during rewind. Number of in memory blocks permits {} after" +
         " rewinding {}.", numberOfInMemBlockRewound, numberOfInMemBlockPermits, this);
 
+  }
+
+  public void rewind(final int baseSeconds, final int windowId) throws IOException
+  {
+    final long longWindowId = (long)baseSeconds << 32 | windowId;
+    logger.debug("Rewinding {} from window ID {} to window ID {}", this, Codec.getStringWindowId(last.ending_window),
+        Codec.getStringWindowId(longWindowId));
+    rewind(longWindowId);
   }
 
   public void reset()
@@ -225,64 +229,63 @@ public class DataList
 
   public void flush(final int writeOffset)
   {
-    //logger.debug("size = {}, processingOffset = {}, nextOffset = {}, writeOffset = {}", size, processingOffset,
-    //    nextOffset.integer, writeOffset);
-    flush:
-    do {
-      while (size == 0) {
-        size = VarInt.read(last.data, processingOffset, writeOffset, nextOffset);
-        if (nextOffset.integer > -5 && nextOffset.integer < 1) {
-          if (writeOffset == last.data.length) {
-            nextOffset.integer = 0;
-            processingOffset = 0;
-            size = 0;
+    size = VarInt.read(last.data, processingOffset, writeOffset, nextOffset);
+
+    if (nextOffset.integer > -5 && nextOffset.integer < 1) {
+      if (writeOffset == last.data.length) {
+        nextOffset.integer = 0;
+        processingOffset = 0;
+        last.writingOffset = writeOffset;
+        return;
+      }
+    } else if (nextOffset.integer == -5) {
+      throw new RuntimeException("problemo!");
+    }
+
+    if (size == 0) {
+      nextOffset.integer = 0;
+      processingOffset = 0;
+      last.writingOffset = writeOffset;
+      return;
+    }
+
+    processingOffset = nextOffset.integer;
+
+    if (processingOffset + size <= writeOffset) {
+      switch (last.data[processingOffset]) {
+        case MessageType.BEGIN_WINDOW_VALUE:
+          Tuple bwt = Tuple.getTuple(last.data, processingOffset, size);
+          if (last.starting_window == -1) {
+            last.starting_window = baseSeconds | bwt.getWindowId();
+            last.ending_window = last.starting_window;
+            //logger.debug("assigned both window id {}", last);
+          } else {
+            last.ending_window = baseSeconds | bwt.getWindowId();
+            //logger.debug("assigned last window id {}", last);
           }
-          break flush;
-        } else if (nextOffset.integer == -5) {
-          throw new RuntimeException("problemo!");
-        }
+          break;
+
+        case MessageType.RESET_WINDOW_VALUE:
+          Tuple rwt = Tuple.getTuple(last.data, processingOffset, size);
+          baseSeconds = (long)rwt.getBaseSeconds() << 32;
+          break;
+
+        default:
+          break;
       }
-
-      processingOffset = nextOffset.integer;
-
-      if (processingOffset + size <= writeOffset) {
-        switch (last.data[processingOffset]) {
-          case MessageType.BEGIN_WINDOW_VALUE:
-            Tuple bwt = Tuple.getTuple(last.data, processingOffset, size);
-            if (last.starting_window == -1) {
-              last.starting_window = baseSeconds | bwt.getWindowId();
-              last.ending_window = last.starting_window;
-              //logger.debug("assigned both window id {}", last);
-            } else {
-              last.ending_window = baseSeconds | bwt.getWindowId();
-              //logger.debug("assigned last window id {}", last);
-            }
-            break;
-
-          case MessageType.RESET_WINDOW_VALUE:
-            Tuple rwt = Tuple.getTuple(last.data, processingOffset, size);
-            baseSeconds = (long)rwt.getBaseSeconds() << 32;
-            break;
-
-          default:
-            break;
-        }
-        processingOffset += size;
+      processingOffset += size;
+      size = 0;
+    } else {
+      if (writeOffset == last.data.length) {
+        nextOffset.integer = 0;
+        processingOffset = 0;
         size = 0;
-      } else {
-        if (writeOffset == last.data.length) {
-          nextOffset.integer = 0;
-          processingOffset = 0;
-          size = 0;
-        }
-        break;
       }
-    } while (true);
+    }
 
     last.writingOffset = writeOffset;
 
     notifyListeners();
-
   }
 
   public void notifyListeners()

--- a/engine/src/main/java/com/datatorrent/stram/engine/StreamingContainer.java
+++ b/engine/src/main/java/com/datatorrent/stram/engine/StreamingContainer.java
@@ -106,15 +106,14 @@ import com.datatorrent.stram.plan.logical.Operators.PortContextPair;
 import com.datatorrent.stram.plan.logical.Operators.PortMappingDescriptor;
 import com.datatorrent.stram.plan.logical.StreamCodecWrapperForPersistance;
 import com.datatorrent.stram.security.StramUserLogin;
-import com.datatorrent.stram.stream.BufferServerPublisher;
 import com.datatorrent.stram.stream.BufferServerSubscriber;
-import com.datatorrent.stram.stream.FastPublisher;
 import com.datatorrent.stram.stream.FastSubscriber;
 import com.datatorrent.stram.stream.InlineStream;
 import com.datatorrent.stram.stream.MuxStream;
 import com.datatorrent.stram.stream.OiOStream;
 import com.datatorrent.stram.stream.PartitionAwareSink;
 import com.datatorrent.stram.stream.PartitionAwareSinkForPersistence;
+import com.datatorrent.stram.stream.QueueServerPublisher;
 import com.datatorrent.stram.util.LoggerUtil;
 
 import net.engio.mbassy.bus.MBassador;
@@ -944,7 +943,7 @@ public class StreamingContainer extends YarnContainerMain
       bssc.setBufferServerAddress(new InetSocketAddress(InetAddress.getByName(null), nodi.bufferServerPort));
     }
 
-    Stream publisher = fastPublisherSubscriber ? new FastPublisher(connIdentifier, queueCapacity * 256) : new BufferServerPublisher(connIdentifier, queueCapacity);
+    Stream publisher = new QueueServerPublisher(connIdentifier, bufferServer);
     return new HashMap.SimpleEntry<>(sinkIdentifier, new ComponentContextPair<>(publisher, bssc));
   }
 

--- a/engine/src/main/java/com/datatorrent/stram/stream/QueueServerPublisher.java
+++ b/engine/src/main/java/com/datatorrent/stram/stream/QueueServerPublisher.java
@@ -1,0 +1,178 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.datatorrent.stram.stream;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.datatorrent.api.StreamCodec;
+import com.datatorrent.bufferserver.packet.BeginWindowTuple;
+import com.datatorrent.bufferserver.packet.DataTuple;
+import com.datatorrent.bufferserver.packet.EndStreamTuple;
+import com.datatorrent.bufferserver.packet.EndWindowTuple;
+import com.datatorrent.bufferserver.packet.MessageType;
+import com.datatorrent.bufferserver.packet.PayloadTuple;
+import com.datatorrent.bufferserver.packet.ResetWindowTuple;
+import com.datatorrent.bufferserver.packet.WindowIdTuple;
+import com.datatorrent.bufferserver.server.Server;
+import com.datatorrent.netlet.util.Slice;
+import com.datatorrent.stram.codec.StatefulStreamCodec;
+import com.datatorrent.stram.engine.ByteCounterStream;
+import com.datatorrent.stram.engine.StreamContext;
+import com.datatorrent.stram.tuple.Tuple;
+
+public class QueueServerPublisher implements ByteCounterStream
+{
+  private StreamCodec<Object> serde;
+  private final AtomicLong publishedByteCount;
+  private int count;
+  private StatefulStreamCodec<Object> statefulSerde;
+  private Server.QueuePublisher queuePublisher;
+  private Server server;
+  private String identifier;
+
+  public QueueServerPublisher(String sourceId, Server server)
+  {
+    this.server = server;
+    this.publishedByteCount = new AtomicLong(0);
+    this.identifier = sourceId;
+  }
+
+  @Override
+  public long getByteCount(boolean reset)
+  {
+    if (reset) {
+      return publishedByteCount.getAndSet(0);
+    }
+
+    return publishedByteCount.get();
+  }
+
+  @Override
+  public void teardown()
+  {
+
+  }
+
+  @Override
+  public void put(Object payload)
+  {
+    count++;
+    byte[] array;
+    if (payload instanceof Tuple) {
+      final Tuple t = (Tuple)payload;
+
+      switch (t.getType()) {
+        case CHECKPOINT:
+          if (statefulSerde != null) {
+            statefulSerde.resetState();
+          }
+          array = WindowIdTuple.getSerializedTuple((int)t.getWindowId());
+          array[0] = MessageType.CHECKPOINT_VALUE;
+          break;
+
+        case BEGIN_WINDOW:
+          array = BeginWindowTuple.getSerializedTuple((int)t.getWindowId());
+          break;
+
+        case END_WINDOW:
+          array = EndWindowTuple.getSerializedTuple((int)t.getWindowId());
+          break;
+
+        case END_STREAM:
+          array = EndStreamTuple.getSerializedTuple((int)t.getWindowId());
+          break;
+
+        case RESET_WINDOW:
+          com.datatorrent.stram.tuple.ResetWindowTuple rwt = (com.datatorrent.stram.tuple.ResetWindowTuple)t;
+          array = ResetWindowTuple.getSerializedTuple(rwt.getBaseSeconds(), rwt.getIntervalMillis());
+          break;
+
+        default:
+          throw new UnsupportedOperationException("this data type is not handled in the stream");
+      }
+    } else {
+      if (statefulSerde == null) {
+
+        Slice slice = serde.toByteArray(payload);
+        int partition = serde.getPartition(payload);
+
+        array = PayloadTuple.getSerializedTuple(partition, slice);
+      } else {
+        StatefulStreamCodec.DataStatePair dsp = statefulSerde.toDataStatePair(payload);
+        /*
+         * if there is any state write that for the subscriber before we write the data.
+         */
+        if (dsp.state != null) {
+          array = DataTuple.getSerializedTuple(MessageType.CODEC_STATE_VALUE, dsp.state);
+          queuePublisher.put(array);
+        }
+        /*
+         * Now that the state if any has been sent, we can proceed with the actual data we want to send.
+         */
+
+        array = PayloadTuple.getSerializedTuple(statefulSerde.getPartition(payload), dsp.data);
+      }
+    }
+
+    queuePublisher.put(array);
+    publishedByteCount.addAndGet(array.length);
+  }
+
+  @Override
+  public int getCount(boolean reset)
+  {
+    try {
+      return count;
+    } finally {
+      if (reset) {
+        count = 0;
+      }
+    }
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void setup(StreamContext context)
+  {
+    StreamCodec<?> codec = context.get(StreamContext.CODEC);
+    if (codec == null) {
+      statefulSerde = ((StatefulStreamCodec<Object>)StreamContext.CODEC.defaultValue).newInstance();
+    } else if (codec instanceof StatefulStreamCodec) {
+      statefulSerde = ((StatefulStreamCodec<Object>)codec).newInstance();
+    } else {
+      serde = (StreamCodec<Object>)codec;
+    }
+  }
+
+  @Override
+  public void activate(StreamContext context)
+  {
+    queuePublisher = server.handleQueuePublisher(context.getFinishedWindowId(), identifier);
+  }
+
+  @Override
+  public void deactivate()
+  {
+  }
+
+  private static final Logger logger = LoggerFactory.getLogger(QueueServerPublisher.class);
+}


### PR DESCRIPTION
Instead of the loop back between the Output port and the buffer server,  tuples are directly written to BufferServer(DataList). This improves the throughput of tuple writes to BufferServer, but exposing the bottleneck between downStream and BufferServer, which in turn mean too much spooling.

This PR along with the following PRs improves the performance to great extent.

https://github.com/apache/apex-core/pull/445
https://github.com/apache/apex-core/pull/436

@vrozov and @PramodSSImmaneni please see.