### PR TITLE
APEXCORE-634 Apex Platform unable to set unifier attributes for modules

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlan.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/logical/LogicalPlan.java
@@ -1039,6 +1039,10 @@ public class LogicalPlan implements Serializable, DAG
       // copy Output port attributes
       for (Map.Entry<OutputPort<?>, OutputPortMeta> entry : operatorMeta.getPortMapping().outPortMap.entrySet()) {
         copyAttributes(getPortMapping().outPortMap.get(entry.getKey()).attributes, entry.getValue().attributes);
+
+        // copy Unifier attributes
+        copyAttributes(getPortMapping().outPortMap.get(entry.getKey()).getUnifierMeta().attributes,
+            entry.getValue().getUnifierMeta().attributes);
       }
     }
 

--- a/engine/src/test/java/com/datatorrent/stram/plan/logical/MockStorageAgent.java
+++ b/engine/src/test/java/com/datatorrent/stram/plan/logical/MockStorageAgent.java
@@ -31,7 +31,8 @@ public class MockStorageAgent implements StorageAgent
   @Override
   public void save(Object object, int operatorId, long windowId) throws IOException
   {
-    throw new UnsupportedOperationException("Not supported yet.");
+    // Do nothing for now
+    return;
   }
 
   @Override


### PR DESCRIPTION
Problem:     Unable to set Unifier attributes of output port within modules
Description: When modules are flatten in logical Plan of DAG, only top level attributes are cloned of OperatorMeta. Unifier attributes are not copied in PortMapping for output ports.
Solution:    Clone the unifier attributes while flattening DAG in logical Plan.

Testing done for custom application with and without modules also with app template HDFS to S3 module. Have had debug logs and stack traces to verify the fix.

One of the snip of logs had set the unifier attribute TIMEOUT_WINDOW_COUNT to 10 ( i.e 1000 millisec)

**Without fix:**
**<log_snip>**
2017-02-06 15:51:31,539 WARN com.datatorrent.stram.StreamingContainerManager: UNIFIER operator PTOperator[id=4,name=**genmodule$gen.out#unifier]** committed window ffffffffffffffff, recovery window ffffffffffffffff, current time 1486376491539, last window id change time 0, **window processing timeout millis 60000**
**</log_snip>**

**With Fix:**
**<log_snip>**
2017-02-06 14:22:49,602 WARN com.datatorrent.stram.StreamingContainerManager: UNIFIER operator PTOperator[id=4,name=**genmodule$gen.out#unifier]** committed window ffffffffffffffff, recovery window ffffffffffffffff, current time 1486371169602, last window id change time 0, **window processing timeout millis 1000**
**</log_snip>**
