### PR TITLE
SPOI-10695: get-app-package-operators with parent option does not work

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/cli/ApexCli.java
+++ b/engine/src/main/java/com/datatorrent/stram/cli/ApexCli.java
@@ -2972,7 +2972,7 @@ public class ApexCli
   public static class GetOperatorClassesCommandLineOptions
   {
     final Options options = new Options();
-    final Option parent = add(new Option("parent", "Specify the parent class for the operators"));
+    final Option parent = add(new Option("parent", true, "Specify the parent class for the operators"));
 
     private Option add(Option opt)
     {


### PR DESCRIPTION
There are two apex command line operators that have the option "-parent" (get-app-package-operators and get-jar-operator-classes). And both of them have the mandatory argument <full name of the parent class>.

The implementation of the class GetOperatorClassesCommandLineOptions that builds command line parser options created the descriptor of the option "-parent" without an argument. And as the result, the argument of the option was ignored and it was moved to the list of the regular command line parameters.

The bug fix is trivial. It defines the option "-parent" as an option with an argument.