### PR TITLE
APEXCORE-644 get-app-package-operators with parent option does not work

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/cli/ApexCli.java
+++ b/engine/src/main/java/com/datatorrent/stram/cli/ApexCli.java
@@ -2998,7 +2998,7 @@ public class ApexCli
   public static class GetOperatorClassesCommandLineOptions
   {
     final Options options = new Options();
-    final Option parent = add(new Option("parent", "Specify the parent class for the operators"));
+    final Option parent = add(new Option("parent", true, "Specify the parent class for the operators"));
 
     private Option add(Option opt)
     {
@@ -3010,13 +3010,13 @@ public class ApexCli
 
   private static GetOperatorClassesCommandLineOptions GET_OPERATOR_CLASSES_OPTIONS = new GetOperatorClassesCommandLineOptions();
 
-  private static class GetOperatorClassesCommandLineInfo
+  static class GetOperatorClassesCommandLineInfo
   {
     String parent;
     String[] args;
   }
 
-  private static GetOperatorClassesCommandLineInfo getGetOperatorClassesCommandLineInfo(String[] args) throws ParseException
+  static GetOperatorClassesCommandLineInfo getGetOperatorClassesCommandLineInfo(String[] args) throws ParseException
   {
     CommandLineParser parser = new PosixParser();
     GetOperatorClassesCommandLineInfo result = new GetOperatorClassesCommandLineInfo();

--- a/engine/src/test/java/com/datatorrent/stram/cli/ApexCliTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/cli/ApexCliTest.java
@@ -258,4 +258,18 @@ public class ApexCliTest
 
     Assert.fail("Cli failed throw multiple apps exception.");
   }
+
+  @Test
+  public void testGetOperatorClassesCommandLineInfo() throws Exception
+  {
+    String arg2 = "option value";
+    String arg3 = "regular parameter";
+
+    ApexCli.GetOperatorClassesCommandLineInfo commandLineOptions =
+        ApexCli.getGetOperatorClassesCommandLineInfo(new String[] {"-parent", arg2, arg3});
+
+    Assert.assertEquals(commandLineOptions.parent, arg2);
+    Assert.assertEquals(commandLineOptions.args.length, 1);
+    Assert.assertEquals(commandLineOptions.args[0], arg3);
+  }
 }


### PR DESCRIPTION
There are two apex command line operators that have the option "-parent" (get-app-package-operators and get-jar-operator-classes). And both of them have the mandatory argument <full name of the parent class>.

The implementation of the class GetOperatorClassesCommandLineOptions that builds command line parser options created the descriptor of the option "-parent" without an argument. And as the result, the argument of the option was ignored and it was moved to the list of the regular command line parameters.

The bug fix is trivial. It defines the option "-parent" as an option with an argument.

The new unit test ApexCliTest.testGetOperatorClassesCommandLineInfo() has been added too.