### PR TITLE
APEXCORE-671 ValueEntry reverted back to public

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/client/DTConfiguration.java
+++ b/engine/src/main/java/com/datatorrent/stram/client/DTConfiguration.java
@@ -70,7 +70,7 @@ public class DTConfiguration implements Iterable<Map.Entry<String, String>>
   private final Map<String, ValueEntry> map = new LinkedHashMap<>();
   private static final Logger LOG = LoggerFactory.getLogger(DTConfiguration.class);
 
-  private static class ValueEntry
+  public static class ValueEntry
   {
     public String value;
     public boolean isFinal = false;


### PR DESCRIPTION
@ajaygit158 @vrozov @sandeshh please see. A more permanent solution can be done later but this currently breaks dependencies.