### PR TITLE
APEXCORE-676 Show description for DefaultProperties in get-app-packag…

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/client/AppPackage.java
+++ b/engine/src/main/java/com/datatorrent/stram/client/AppPackage.java
@@ -34,6 +34,10 @@ import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.JsonProcessingException;
+import org.codehaus.jackson.map.JsonSerializer;
+import org.codehaus.jackson.map.SerializerProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -128,6 +132,31 @@ public class AppPackage extends JarFile
     public String getDescription()
     {
       return description;
+    }
+  }
+
+  public static class PropertyInfoSerializer extends JsonSerializer<PropertyInfo>
+  {
+    private boolean provideDescription;
+
+    public PropertyInfoSerializer(boolean provideDescription)
+    {
+      this.provideDescription = provideDescription;
+    }
+
+    @Override
+    public void serialize(
+        PropertyInfo propertyInfo, JsonGenerator jgen, SerializerProvider provider)
+      throws IOException, JsonProcessingException
+    {
+      if (provideDescription) {
+        jgen.writeStartObject();
+        jgen.writeStringField("value", propertyInfo.value);
+        jgen.writeStringField("description", propertyInfo.description);
+        jgen.writeEndObject();
+      } else {
+        jgen.writeString(propertyInfo.value);
+      }
     }
   }
 

--- a/engine/src/test/java/com/datatorrent/stram/client/AppPackageTest.java
+++ b/engine/src/test/java/com/datatorrent/stram/client/AppPackageTest.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.codehaus.jackson.JsonGenerationException;
+import org.codehaus.jackson.map.JsonMappingException;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.junit.AfterClass;
@@ -34,6 +36,7 @@ import org.junit.Test;
 
 import org.apache.commons.io.IOUtils;
 
+import com.datatorrent.stram.client.AppPackage.PropertyInfo;
 import com.datatorrent.stram.support.StramTestSupport;
 import com.datatorrent.stram.util.JSONSerializationProvider;
 
@@ -139,5 +142,20 @@ public class AppPackageTest
       }
     }
     Assert.fail("Should consist of an app called MyFirstApplication");
+  }
+
+  @Test
+  public void testPropertyInfoSerializer() throws JsonGenerationException, JsonMappingException, IOException
+  {
+    AppPackage.PropertyInfo propertyInfo = new AppPackage.PropertyInfo("test-value", "test-description");
+    JSONSerializationProvider jomp = new JSONSerializationProvider();
+    jomp.addSerializer(PropertyInfo.class, new AppPackage.PropertyInfoSerializer(false));
+    String result = jomp.getContext(null).writeValueAsString(propertyInfo);
+    Assert.assertEquals("\"test-value\"", result);
+
+    jomp = new JSONSerializationProvider();
+    jomp.addSerializer(PropertyInfo.class, new AppPackage.PropertyInfoSerializer(true));
+    result = jomp.getContext(null).writeValueAsString(propertyInfo);
+    Assert.assertEquals("{\"value\":\"test-value\",\"description\":\"test-description\"}", result);
   }
 }


### PR DESCRIPTION
…e-info command  only when user requests it by providing --with-description flag

**Output without --with-description flag
Command : get-app-package-info {apa-file}**

"defaultProperties": { "dt.application.*.operator.*.attr.JVM_OPTIONS": "-Xmx128M", "dt.application.*.operator.*.attr.MEMORY_MB": "256" }

**Output with --with-description flag
Command : get-app-package-info {apa-file} --with-description**
"defaultProperties": {
"dt.application..operator..attr.JVM_OPTIONS":
{ "value": "-Xmx128M", "description": null }
,
"dt.application..operator..attr.MEMORY_MB":
{ "value": "256", "description": null }
}

**Invalid argument 
get-app-package-info {apa-file} --with-descripti
Output:**
com.datatorrent.stram.cli.ApexCli$CliException: Invalid parameter --with-descripti
at com.datatorrent.stram.cli.ApexCli$GetAppPackageInfoCommand.execute(ApexCli.java:3482)
at com.datatorrent.stram.cli.ApexCli$3.run(ApexCli.java:1519)