### PR TITLE
APEXCORE-678 Fixed shutdown of input nodes in StreamingContainer

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/engine/StreamingContainer.java
+++ b/engine/src/main/java/com/datatorrent/stram/engine/StreamingContainer.java
@@ -849,8 +849,8 @@ public class StreamingContainer extends YarnContainerMain
         if (thread == null || !thread.isAlive()) {
           continue;
         }
+        node.shutdown(true);
       }
-      node.shutdown(true);
     }
   }
 


### PR DESCRIPTION
This was a straightforward bug. Also did not find any easy way to add test for it.

@tushargosavi please see