### PR TITLE
APEXCORE-703 Window processing timeout for finished/undeployed container.

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/StreamingContainerManager.java
+++ b/engine/src/main/java/com/datatorrent/stram/StreamingContainerManager.java
@@ -1378,6 +1378,7 @@ public class StreamingContainerManager implements PlanContext
                 }
                 deactivatedOpers.add(oper);
               }
+              oper.setState(State.INACTIVE);
               sca.undeployOpers.add(oper.getId());
               slowestUpstreamOp.remove(oper);
               // record operator stop event

--- a/engine/src/main/java/com/datatorrent/stram/plan/physical/PTOperator.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/physical/PTOperator.java
@@ -497,7 +497,7 @@ public class PTOperator implements java.io.Serializable
   @Override
   public String toString()
   {
-    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("id", id).append("name", name).toString();
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("id", id).append("name", name).append("state", state).toString();
   }
 
 }

--- a/engine/src/main/java/com/datatorrent/stram/plan/physical/PhysicalPlan.java
+++ b/engine/src/main/java/com/datatorrent/stram/plan/physical/PhysicalPlan.java
@@ -1440,7 +1440,7 @@ public class PhysicalPlan implements Serializable
 
   void removePTOperator(PTOperator oper)
   {
-    LOG.debug("Removing operator " + oper);
+    LOG.debug("Removing operator {}", oper);
 
     // per partition merge operators
     if (!oper.upstreamMerge.isEmpty()) {


### PR DESCRIPTION
During an operator shutdown, mark it as INACTIVE to exclude it from the blocked operators check.
@tweise Please review.