### PR TITLE
APEXCORE-767.set parent classloader in StramAppLauncher.loadDependencies

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/cli/ApexCli.java
+++ b/engine/src/main/java/com/datatorrent/stram/cli/ApexCli.java
@@ -2151,7 +2151,7 @@ public class ApexCli
         } else {
           System.err.println("No application specified.");
         }
-
+        submitApp.resetContextClassLoader();
       } finally {
         IOUtils.closeQuietly(cp);
       }
@@ -2911,8 +2911,10 @@ public class ApexCli
           submitApp.loadDependencies();
           List<AppFactory> matchingAppFactories = getMatchingAppFactories(submitApp, appName, commandLineInfo.exactMatch);
           if (matchingAppFactories == null || matchingAppFactories.isEmpty()) {
+            submitApp.resetContextClassLoader();
             throw new CliException("No application in jar file matches '" + appName + "'");
           } else if (matchingAppFactories.size() > 1) {
+            submitApp.resetContextClassLoader();
             throw new CliException("More than one application in jar file match '" + appName + "'");
           } else {
             Map<String, Object> map = new HashMap<>();
@@ -2940,6 +2942,7 @@ public class ApexCli
               }
             }
             printJson(map);
+            submitApp.resetContextClassLoader();
           }
         } else {
           if (filename.endsWith(".json")) {
@@ -2971,6 +2974,7 @@ public class ApexCli
               appList.add(m);
             }
             printJson(appList, "applications");
+            submitApp.resetContextClassLoader();
           }
         }
       } else {
@@ -3200,8 +3204,10 @@ public class ApexCli
         submitApp.loadDependencies();
         List<AppFactory> matchingAppFactories = getMatchingAppFactories(submitApp, appName, true);
         if (matchingAppFactories == null || matchingAppFactories.isEmpty()) {
+          submitApp.resetContextClassLoader();
           throw new CliException("No application in jar file matches '" + appName + "'");
         } else if (matchingAppFactories.size() > 1) {
+          submitApp.resetContextClassLoader();
           throw new CliException("More than one application in jar file match '" + appName + "'");
         } else {
           AppFactory appFactory = matchingAppFactories.get(0);
@@ -3211,6 +3217,7 @@ public class ApexCli
             file.createNewFile();
           }
           LogicalPlanSerializer.convertToProperties(logicalPlan).save(file);
+          submitApp.resetContextClassLoader();
         }
       } else {
         if (currentApp == null) {

--- a/engine/src/main/java/com/datatorrent/stram/client/AppPackage.java
+++ b/engine/src/main/java/com/datatorrent/stram/client/AppPackage.java
@@ -465,8 +465,9 @@ public class AppPackage implements Closeable
 
       if (entry.getName().endsWith(".jar") && !skipJars) {
         appJars.add(entry.getName());
+        StramAppLauncher stramAppLauncher = null;
         try {
-          StramAppLauncher stramAppLauncher = new StramAppLauncher(entry, config);
+          stramAppLauncher = new StramAppLauncher(entry, config);
           stramAppLauncher.loadDependencies();
           List<AppFactory> appFactories = stramAppLauncher.getBundledTopologies();
           for (AppFactory appFactory : appFactories) {
@@ -486,6 +487,10 @@ public class AppPackage implements Closeable
           }
         } catch (Exception ex) {
           LOG.error("Caught exception trying to process {}", entry.getName(), ex);
+        } finally {
+          if (stramAppLauncher != null) {
+            stramAppLauncher.resetContextClassLoader();
+          }
         }
       }
     }

--- a/engine/src/main/java/org/apache/apex/engine/YarnAppLauncherImpl.java
+++ b/engine/src/main/java/org/apache/apex/engine/YarnAppLauncherImpl.java
@@ -80,6 +80,7 @@ public class YarnAppLauncherImpl extends YarnAppLauncher<YarnAppLauncherImpl.Yar
         }
       };
       ApplicationId appId = appLauncher.launchApp(appFactory);
+      appLauncher.resetContextClassLoader();
       return new YarnAppHandleImpl(appId, conf);
     } catch (Exception ex) {
       throw new LauncherException(ex);

--- a/engine/src/test/java/com/datatorrent/stram/client/AsyncTester.java
+++ b/engine/src/test/java/com/datatorrent/stram/client/AsyncTester.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.datatorrent.stram.client;
+
+// See https://stackoverflow.com/a/2596530
+public class AsyncTester
+{
+  private Thread thread;
+  private volatile AssertionError error;
+
+  public AsyncTester(final Runnable runnable)
+  {
+    thread = new Thread(new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        try {
+          runnable.run();
+        } catch (AssertionError e) {
+          error = e;
+        }
+      }
+    });
+  }
+
+  public AsyncTester start()
+  {
+    thread.start();
+    return this;
+  }
+
+  public void test() throws AssertionError, InterruptedException
+  {
+    thread.join();
+    if (error != null) {
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
Following below is my understanding of the problem (should be probably taken with a grain of salt, as I just started digging in to the apex-core codebase):

StramAppLauncher.loadDependencies is called multiple times when starting
an application via the apex-cli with the -local option. In each of the
calls to loadDependencies, the contextClassLoader of the current thread
would be replaced with a new instance of URLClassLoader (which has no
parent class loader set).

This can lead to issues, e.g. when one acquires the current
contextClassLauncher, loads a class with it and tries to cast it to a
class which was loaded with a previous instance of the contextClassLoader,
resulting in a ClassCastException.

An example of this bug can be seen in APEXMALHAR-2511

The changes in this pr fix this by passing the parent class loader
for each new instance of URLClassLoader to the current
contextClassLoader

I am still in the process of figuring how the StramAppLauncher works and why the dependencies get loaded multiple times in the first place, is this intended behavior? Otherwise I could also look into what is going on there as well. (See discussion on JIRA)