### PR TITLE
APEXCORE-569 : Fixing javadoc errors with jdk8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -563,5 +563,14 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>disable-javadoc-doclint</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <additionalparam>-Xdoclint:none</additionalparam>
+      </properties>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
This commit fixes the issues found while preparing javadocs with jdk8.