### PR TITLE
upgrade maven-checkstyle-plugin to 3.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -393,7 +393,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>2.17</version>
+          <version>3.1.1</version>
           <dependencies>
             <dependency>
               <groupId>org.apache.apex</groupId>


### PR DESCRIPTION
Checkstyle is adding this mirror of apex-core to their regression testing in place of the original apex-core repository. We noticed that you are on an older version of maven-checkstyle-plugin, which is still using some deprecated methods we are removing, could you merge this upgrade so that Checkstyle can test regression against this repository?

Related to Issue:
Issue: checkstyle/checkstyle/issues/7190
PR: checkstyle/checkstyle#7778